### PR TITLE
Prevent "Parameter must be scalar" error when creating a calendar event

### DIFF
--- a/calendar/inc/class.calendar_uiforms.inc.php
+++ b/calendar/inc/class.calendar_uiforms.inc.php
@@ -368,76 +368,79 @@ class calendar_uiforms extends calendar_ui
 						case 'participant':
 							foreach($data as $participant)
 							{								// email or rfc822 addresse (eg. "Ralf Becker <ralf@domain.com>")
-								$email = array();
-								if(preg_match('/^(.*<)?([a-z0-9_.-]+@[a-z0-9_.-]{5,})>?$/i',$participant,$email))
-								{
-									$status = calendar_so::combine_status('U',$content['participants']['quantity'],$content['participants']['role']);
-									if (($data = $GLOBALS['egw']->accounts->name2id($email[2],'account_email')) && $this->bo->check_acl_invite($data))
-									{
-										$event['participants'][$data] = $event['participant_types']['u'][$data] = $status;
-									}
-									elseif ((list($data) = ExecMethod2('addressbook.addressbook_bo.search',array(
-										'email' => $email[2],
-										'email_home' => $email[2],
-									),true,'','','',false,'OR')))
-									{
-										$event['participants']['c'.$data['id']] = $event['participant_types']['c'][$data['id']] = $status;
-									}
-									else
-									{
-										$event['participants']['e'.$participant] = $event['participant_types']['e'][$participant] = $status;
-									}
-								}
-								else
-								{
-									if(is_numeric($participant))
-									{
-										$uid = 'u'.$participant;
-										$id = $participant;
-										$resource = $this->bo->resources[''];
-									}
-									else
-									{
-										$uid = $participant;
-										$id = substr($participant,1);
-										$resource = $this->bo->resources[$participant[0]];
-									}
-									if(!$this->bo->check_acl_invite($uid))
-									{
-										if(!$msg_permission_denied_added)
-										{
-											$msg .= lang('Permission denied!');
-											$msg_permission_denied_added = true;
-										}
-										continue;
-									}
+                                                                if (!is_null($participant))
+                                                                {
+                                                                    $email = array();
+                                                                    if(preg_match('/^(.*<)?([a-z0-9_.-]+@[a-z0-9_.-]{5,})>?$/i',$participant,$email))
+                                                                    {
+                                                                            $status = calendar_so::combine_status('U',$content['participants']['quantity'],$content['participants']['role']);
+                                                                            if (($data = $GLOBALS['egw']->accounts->name2id($email[2],'account_email')) && $this->bo->check_acl_invite($data))
+                                                                            {
+                                                                                    $event['participants'][$data] = $event['participant_types']['u'][$data] = $status;
+                                                                            }
+                                                                            elseif ((list($data) = ExecMethod2('addressbook.addressbook_bo.search',array(
+                                                                                    'email' => $email[2],
+                                                                                    'email_home' => $email[2],
+                                                                            ),true,'','','',false,'OR')))
+                                                                            {
+                                                                                    $event['participants']['c'.$data['id']] = $event['participant_types']['c'][$data['id']] = $status;
+                                                                            }
+                                                                            else
+                                                                            {
+                                                                                    $event['participants']['e'.$participant] = $event['participant_types']['e'][$participant] = $status;
+                                                                            }
+                                                                    }
+                                                                    else
+                                                                    {
+                                                                            if(is_numeric($participant))
+                                                                            {
+                                                                                    $uid = 'u'.$participant;
+                                                                                    $id = $participant;
+                                                                                    $resource = $this->bo->resources[''];
+                                                                            }
+                                                                            else
+                                                                            {
+                                                                                    $uid = $participant;
+                                                                                    $id = substr($participant,1);
+                                                                                    $resource = $this->bo->resources[$participant[0]];
+                                                                            }
+                                                                            if(!$this->bo->check_acl_invite($uid))
+                                                                            {
+                                                                                    if(!$msg_permission_denied_added)
+                                                                                    {
+                                                                                            $msg .= lang('Permission denied!');
+                                                                                            $msg_permission_denied_added = true;
+                                                                                    }
+                                                                                    continue;
+                                                                            }
 
-									$type = $resource['type'];
-									$status = isset($this->bo->resources[$type]['new_status']) ?
-										ExecMethod($this->bo->resources[$type]['new_status'],$id) :
-										($uid == $this->bo->user ? 'A' : 'U');
+                                                                            $type = $resource['type'];
+                                                                            $status = isset($this->bo->resources[$type]['new_status']) ?
+                                                                                    ExecMethod($this->bo->resources[$type]['new_status'],$id) :
+                                                                                    ($uid == $this->bo->user ? 'A' : 'U');
 
-									if ($status)
-									{
-										$res_info = $this->bo->resource_info($uid);
-										// todo check real availability = maximum - already booked quantity
-										if (isset($res_info['useable']) && $content['participants']['quantity'] > $res_info['useable'])
-										{
-											$msg .= lang('Maximum available quantity of %1 exceeded!',$res_info['useable']);
-											foreach(array('quantity','resource','role') as $n)
-											{
-												$event['participants'][$n] = $content['participants'][$n];
-											}
-											continue;
-										}
-										else
-										{
-											$event['participants'][$uid] = $event['participant_types'][$type][$id] =
-												calendar_so::combine_status($status,$content['participants']['quantity'],$content['participants']['role']);
-										}
-									}
-								}
-							}
+                                                                            if ($status)
+                                                                            {
+                                                                                    $res_info = $this->bo->resource_info($uid);
+                                                                                    // todo check real availability = maximum - already booked quantity
+                                                                                    if (isset($res_info['useable']) && $content['participants']['quantity'] > $res_info['useable'])
+                                                                                    {
+                                                                                            $msg .= lang('Maximum available quantity of %1 exceeded!',$res_info['useable']);
+                                                                                            foreach(array('quantity','resource','role') as $n)
+                                                                                            {
+                                                                                                    $event['participants'][$n] = $content['participants'][$n];
+                                                                                            }
+                                                                                            continue;
+                                                                                    }
+                                                                                    else
+                                                                                    {
+                                                                                            $event['participants'][$uid] = $event['participant_types'][$type][$id] =
+                                                                                                    calendar_so::combine_status($status,$content['participants']['quantity'],$content['participants']['role']);
+                                                                                    }
+                                                                            }
+                                                                    }
+                                                            }
+                                                        }
 							break;
 						case 'add':
 							if (!$content['participants']['participant'])


### PR DESCRIPTION
In version 16.1.20160715 when a user creates a calendar event, it fails with the following error in the apache logs (Apache 2.4.23, PHP 7.0.8):

 An error happened (EGroupware\\Api\\Exception\\WrongParameter): calendar_bo::resource_info(NULL) parameter must be scalar, referer: https://egroupware.XXXX.org/index.php?menuaction=calendar.calendar_uiforms.edit&date=20160719&hour=7&minute=30&owner[]=11
 #0 C:\\Web\\sites\\egroupware\\calendar\\inc\\class.calendar_uiforms.inc.php(422): calendar_bo->resource_info(NULL), referer: https://egroupware.XXXX.org/index.php?menuaction=calendar.calendar_uiforms.edit&date=20160719&hour=7&minute=30&owner[]=11
 #1 C:\\Web\\sites\\egroupware\\api\\src\\loader\\deprecated_factory.php(191): calendar_uiforms->process_edit(Array), referer: https://egroupware.XXXX.org/index.php?menuaction=calendar.calendar_uiforms.edit&date=20160719&hour=7&minute=30&owner[]=11
 #2 C:\\Web\\sites\\egroupware\\api\\src\\Etemplate.php(366): ExecMethod(Array, Array), referer: https://egroupware.XXXX.org/index.php?menuaction=calendar.calendar_uiforms.edit&date=20160719&hour=7&minute=30&owner[]=11
 #3 [internal function]: EGroupware\\Api\\Etemplate::ajax_process_content('calendar_egroup...', Array, ''), referer: https://egroupware.sau19.org/index.php?menuaction=calendar.calendar_uiforms.edit&date=20160719&hour=7&minute=30&owner[]=11
 C:\\Web\\sites\\egroupware\\api\\src\\Json\\Request.php(179): call_user_func_array(Array, Array), referer: https://egroupware.XXXX.org/index.php?menuaction=calendar.calendar_uiforms.edit&date=20160719&hour=7&minute=30&owner[]=11
 #5 C:\\Web\\sites\\egroupware\\api\\src\\Json\\Request.php(91): EGroupware\\Api\\Json\\Request->handleRequest('EGroupware\\\\Api\\\\...', Array), referer: https://egroupware.XXXX.org/index.php?menuaction=calendar.calendar_uiforms.edit&date=20160719&hour=7&minute=30&owner[]=11
 #6 C:\\Web\\sites\\egroupware\\json.php(119): EGroupware\\Api\\Json\\Request->parseRequest('EGroupware\\\\Api\\\\...', '{"request":{"pa...'), referer: https://egroupware.XXXX.org/index.php?menuaction=calendar.calendar_uiforms.edit&date=20160719&hour=7&minute=30&owner[]=11
 #7 {main}, referer: https://egroupware.XXXX.org/index.php?menuaction=calendar.calendar_uiforms.edit&date=20160719&hour=7&minute=30&owner[]=11
 # Instance=default, User=egroupware, Request=POST https://egroupware.XXXX.org/json.php?menuaction=EGroupware\\Api\\Etemplate::ajax_process_content, User-agent=Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0, referer: https://egroupware.XXXX.org/index.php?menuaction=calendar.calendar_uiforms.edit&date=20160719&hour=7&minute=30&owner[]=11

This occurs because the $participant has a value of null during one of the iterations of the foreach loop.  This patch simply checks to see if there is a value before executing the code within the loop.