### PR TITLE
Sendmail transport

### DIFF
--- a/admin/templates/default/config.xet
+++ b/admin/templates/default/config.xet
@@ -267,6 +267,16 @@
 					</vbox>
 					<textbox id="newsettings[recaptcha_site]" size="60"/>
 				</row>
+				<row>
+					<description value="Emails" span="all" class="subHeader"/>
+				</row>
+				<row>
+					<description value="Force sending email via Sendmail transport (local mail)" label="%s:"/>
+					<select id="newsettings[sendmail]">
+						<option value="">{No} - {Default}</option>
+						<option value="True">Yes</option>
+					</select>
+				</row>
 			</rows>
 		</grid>
 	</template>

--- a/api/src/Mail/Account.php
+++ b/api/src/Mail/Account.php
@@ -18,6 +18,7 @@ use EGroupware\Api;
 
 use Horde_Imap_Client_Exception;
 use Horde_Mail_Transport_Smtphorde;
+use Horde_Mail_Transport_Sendmail;
 
 /**
  * Mail accounts supports 3 types of accounts:
@@ -466,15 +467,22 @@ class Account implements \ArrayAccess
 			// Horde use locale for translation of error messages
 			Api\Preferences::setlocale(LC_MESSAGES);
 
-			$this->smtpTransport = new Horde_Mail_Transport_Smtphorde(array(
-				'username' => $this->acc_smtp_username,
-				'password' => $this->acc_smtp_password,
-				'host' => $this->acc_smtp_host,
-				'port' => $this->acc_smtp_port,
-				'secure' => $secure,
-				'debug' => self::SMTP_DEBUG_LOG,
-				//'timeout' => self::TIMEOUT,
-			));
+			if (!empty($GLOBALS['egw_info']['server']['sendmail']))
+			{
+				$this->smtpTransport = new Horde_Mail_Transport_Sendmail();
+			}
+			else
+			{
+				$this->smtpTransport = new Horde_Mail_Transport_Smtphorde(array(
+					'username' => $this->acc_smtp_username,
+					'password' => $this->acc_smtp_password,
+					'host' => $this->acc_smtp_host,
+					'port' => $this->acc_smtp_port,
+					'secure' => $secure,
+					'debug' => self::SMTP_DEBUG_LOG,
+					//'timeout' => self::TIMEOUT,
+				));
+			}
 		}
 		return $this->smtpTransport;
 	}

--- a/api/src/Mail/Account.php
+++ b/api/src/Mail/Account.php
@@ -467,7 +467,10 @@ class Account implements \ArrayAccess
 			// Horde use locale for translation of error messages
 			Api\Preferences::setlocale(LC_MESSAGES);
 
-			if (!empty($GLOBALS['egw_info']['server']['sendmail']))
+			$api_config = Api\Config::read('phpgwapi');
+
+			if (!empty($GLOBALS['egw_info']['server']['sendmail']) ||
+				!empty($api_config['sendmail']))
 			{
 				$this->smtpTransport = new Horde_Mail_Transport_Sendmail();
 			}

--- a/api/src/Mailer.php
+++ b/api/src/Mailer.php
@@ -17,7 +17,6 @@ use Horde_Mime_Part;
 use Horde_Mail_Rfc822_List;
 use Horde_Mail_Exception;
 use Horde_Mail_Transport;
-use Horde_Mail_Transport_Sendmail;
 use Horde_Mail_Transport_Null;
 use Horde_Mime_Headers_MessageId;
 use Horde_Text_Flowed;
@@ -503,13 +502,6 @@ class Mailer extends Horde_Mime_Mail
 	function send(Horde_Mail_Transport $transport=null, $resend=true, $flowed=null)
 	{
 		unset($resend);	// parameter is not used, but required by function signature
-
-		if ($transport === null &&
-			isset($GLOBALS['egw_info']['server']['sendmail']) &&
-			$GLOBALS['egw_info']['server']['sendmail'])
-		{
-			$transport = new Horde_Mail_Transport_Sendmail();
-		}
 
 		if (!($message_id = $this->getHeader('Message-ID')) &&
 			class_exists('Horde_Mime_Headers_MessageId'))	// since 2.5.0

--- a/api/src/Mailer.php
+++ b/api/src/Mailer.php
@@ -17,6 +17,7 @@ use Horde_Mime_Part;
 use Horde_Mail_Rfc822_List;
 use Horde_Mail_Exception;
 use Horde_Mail_Transport;
+use Horde_Mail_Transport_Sendmail;
 use Horde_Mail_Transport_Null;
 use Horde_Mime_Headers_MessageId;
 use Horde_Text_Flowed;
@@ -502,6 +503,13 @@ class Mailer extends Horde_Mime_Mail
 	function send(Horde_Mail_Transport $transport=null, $resend=true, $flowed=null)
 	{
 		unset($resend);	// parameter is not used, but required by function signature
+
+		if ($transport === null &&
+			isset($GLOBALS['egw_info']['server']['sendmail']) &&
+			$GLOBALS['egw_info']['server']['sendmail'])
+		{
+			$transport = new Horde_Mail_Transport_Sendmail();
+		}
 
 		if (!($message_id = $this->getHeader('Message-ID')) &&
 			class_exists('Horde_Mime_Headers_MessageId'))	// since 2.5.0


### PR DESCRIPTION
Added a configuration option to force all mail go through local sendmail transport.
This allows mail to work on restrictive shared hosting