### PR TITLE
Fix multibyte bug on utf-8 import

### DIFF
--- a/importexport/inc/class.importexport_import_ui.inc.php
+++ b/importexport/inc/class.importexport_import_ui.inc.php
@@ -74,8 +74,7 @@ use EGroupware\Api\Etemplate;
 					$plugin = new $definition_obj->plugin;
 
 					// Check file encoding matches import
-					$sample = file_get_contents($content['file']['tmp_name']);
-					$sample = mb_substr( $sample, 1024 );
+					$sample = mb_substr(file_get_contents($content['file']['tmp_name'], false, null, 0, 2048), 1024);
 
 					if($appname == 'addressbook' && $definition_obj->plugin == 'addressbook_import_vcard')
 					{

--- a/importexport/inc/class.importexport_import_ui.inc.php
+++ b/importexport/inc/class.importexport_import_ui.inc.php
@@ -74,7 +74,9 @@ use EGroupware\Api\Etemplate;
 					$plugin = new $definition_obj->plugin;
 
 					// Check file encoding matches import
-					$sample = file_get_contents($content['file']['tmp_name'],false, null, 0, 1024);
+					$sample = file_get_contents($content['file']['tmp_name']);
+					$sample = mb_substr( $sample, 1024 );
+
 					if($appname == 'addressbook' && $definition_obj->plugin == 'addressbook_import_vcard')
 					{
 						$preference = $GLOBALS['egw_info']['user']['preferences']['addressbook']['vcard_charset'];


### PR DESCRIPTION
Right now, when trying to import a csv file, we get a sample of the first 1024 bytes.

If the file is in UTF-8 however, there is a chance to split the final character in case it's a multibyte one.
After that, the file's encoding is not recognized as UTF-8

So, we use php's mb_substr to make sure we don't accidentally split any multibyte characters.