### PR TITLE
If Mail Account has empty password, it's still regarded as imap

### DIFF
--- a/api/src/Mail/Account.php
+++ b/api/src/Mail/Account.php
@@ -397,7 +397,7 @@ class Account implements \ArrayAccess
 	 */
 	public function is_imap($try_connect=true)
 	{
-		if (empty($this->acc_imap_host) && empty($this->acc_imap_username) && empty($this->acc_imap_password))
+		if (empty($this->acc_imap_host) || ( empty($this->acc_imap_username) && empty($this->acc_imap_password) ) )
 		{
 			return false;	// no imap host or credentials
 		}

--- a/api/src/Mail/Account.php
+++ b/api/src/Mail/Account.php
@@ -397,7 +397,7 @@ class Account implements \ArrayAccess
 	 */
 	public function is_imap($try_connect=true)
 	{
-		if (empty($this->acc_imap_host) || empty($this->acc_imap_username) || empty($this->acc_imap_password))
+		if (empty($this->acc_imap_host) && empty($this->acc_imap_username) && empty($this->acc_imap_password))
 		{
 			return false;	// no imap host or credentials
 		}


### PR DESCRIPTION
Right now, if a mail account has no password, it fails to be recognized as a valid imap account.

This creates issues if one tries to edit this account later. Since it's not recognized as a imap account, the wizard prompts the user to create a new account, and not edit the existing one.