### PR TITLE
Save as zip in mail popup

### DIFF
--- a/mail/js/app.js
+++ b/mail/js/app.js
@@ -2915,7 +2915,7 @@ app.classes.mail = AppJS.extend(
 		else
 		{
 			mailid = this.et2.getArrayMgr("content").getEntry('mail_id');
-			attgrid = this.et2.getArrayMgr("content").getEntry('mail_displayattachments')[widget.id.replace(/\[save\]/,'')];
+			attgrid = this.et2.getArrayMgr("content").getEntry('mail_displayattachments')[widget.id.replace(/\[save_zip\]/,'')];
 		}
 		var url = window.egw_webserverUrl+'/index.php?';
 		url += 'menuaction=mail.mail_ui.download_zip';	// todo compose for Draft folder


### PR DESCRIPTION
Issue:

When trying to save multiple as zip in mail popup (not main window/preview), we get a js error "attgrid not defined"

Fixed the name of the widget ("save_zip" instead of "save"), and now it works