### PR TITLE
[notifications] Added new functionality to expand/collapse the notifications in a popup

### DIFF
--- a/notifications/js/notificationajaxpopup.js
+++ b/notifications/js/notificationajaxpopup.js
@@ -79,6 +79,11 @@
 					.attr('id', message_id);
 			$message[0].innerHTML = notifymessages[show]['message'];
 			$delete = jQuery(document.createElement('span'))
+					.addClass('egwpopup_expand')
+					.attr('title',egw.lang('expand/collapse notification'))
+					.click(jQuery.proxy(this.button_expand, this,[$message]))
+					.prependTo($message);
+			$delete = jQuery(document.createElement('span'))
 					.addClass('egwpopup_delete')
 					.attr('title',egw.lang('delete this message'))
 					.click(jQuery.proxy(this.button_delete, this,[$message]))
@@ -242,6 +247,15 @@
 		egwpopup_message.hide();
 		this.bell("inactive");
 		this.counterUpdate();
+	};
+
+	/**
+	 * Callback for expand button: Expand notification
+	 */
+	notifications.prototype.button_expand = function(_node, _event) {
+		_event.stopPropagation();
+		var egwpopup_message = _node[0];
+        egwpopup_message.toggleClass('notification_expanded');
 	};
 
 	/**

--- a/pixelegg/css/pixelegg.css
+++ b/pixelegg/css/pixelegg.css
@@ -6195,6 +6195,34 @@ span.egw_tutorial_title {
   white-space: nowrap;
   overflow-x: hidden;
 }
+/* Modify notification height. */
+#egwpopup #egwpopup_list .egwpopup_message {
+    height: 140px;
+    overflow: scroll;
+}
+/* Make Notifications Expandable */
+#egwpopup #egwpopup_list .egwpopup_message.notification_expanded {
+    position: fixed;
+    top: 5vh;
+    height: 90vh;
+    left: 20vw;
+    width: 60vw;
+    box-shadow: 0 0 40px #666;
+}
+#egwpopup #egwpopup_list .egwpopup_message.notification_expanded:hover {
+    background-color: #fafafa;
+}
+#egwpopup #egwpopup_list span.egwpopup_expand {
+  display: inline-block;
+  float: right;
+  width: 24px;
+  height: 24px;
+  background-image: url(../images/search.png);
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 12px;
+  cursor: pointer;
+}
 /*@import "../less/layout_buttons_global.less";*/
 /*@import "../less/layout_chosen.less";*/
 /*@import "../less/layout_messages.less";*/


### PR DESCRIPTION
I went ahead and put some CSS in the pixelegg.css file
Not sure if this is the correct way to proceed, or if I should use LESS in some way. Please advise.