### PR TITLE
Historylog widget: Ability to set nextmatch num_rows

### DIFF
--- a/api/js/etemplate/et2_widget_historylog.js
+++ b/api/js/etemplate/et2_widget_historylog.js
@@ -420,6 +420,10 @@ var et2_historylog = (function(){ "use strict"; return et2_valueWidget.extend([e
 		// Skip getting data if there's no ID
 		if(!this.value.id) return;
 
+		// Set num_rows to fetch via nextmatch
+		if ( this.options.value['num_rows'] )
+			_queriedRange['num_rows'] = this.options.value['num_rows'];
+
 		// Pass the fetch call to the API
 		this.egw().dataFetch(
 			this.getInstanceManager().etemplate_exec_id,

--- a/api/src/Storage/Tracking.php
+++ b/api/src/Storage/Tracking.php
@@ -56,6 +56,7 @@ use notifications;
  * $content['history'] = array(
  * 	'id' => 123,
  *  'app' => 'calendar',
+ *  'num_rows' => 50, // optional, defaults to 50
  *  'status-widgets' => array(
  * 		'title' => 'label',	// no need to set, as default is label
  * 		'date'  => 'datetime',


### PR DESCRIPTION
Right now, the historylog widget fetches the 50 latest entries from db via nextmatch, with no option to make this number smaller or larger. 

To change this, we can just apply our own num_rows (if it is set) when ajax_get_rows is called.

The way to set this is in the widget's content. I have added the appropriate line into Tracking's inline documentation as well.

Usage:
````
$content['history'] = array(
    'id' => 123,
    'app' => 'calendar',
    'num_rows' => 50, // optional, defaults to 50
    'status-widgets' => array(...),
);