### PR TITLE
fix php 7.1 error/warning/exception causing 401 authentication popup on the browser

### DIFF
--- a/api/src/Session.php
+++ b/api/src/Session.php
@@ -965,7 +965,7 @@ class Session
 			// session only stores app-names, restore apps from egw_info[apps]
 			if (!is_array($GLOBALS['egw_info']['user']['apps']['api']))
 			{
-				$GLOBALS['egw_info']['user']['apps'] = array_intersect_key($GLOBALS['egw_info']['apps'], array_flip($GLOBALS['egw_info']['user']['apps']));
+				$GLOBALS['egw_info']['user']['apps'] = array_intersect_key($GLOBALS['egw_info']['apps'], $GLOBALS['egw_info']['user']['apps']);
 			}
 
 			// set prefs, they are no longer stored in session


### PR DESCRIPTION
fix a very rare error with session handling, that causes an exception on PHP7.1, resulting in a authentication popup during download of a series of shared files (sent via link). the error occurs only after the second file of the series has been downloaded.
