### PR TITLE
proper fix for rare issue with Session initialization/ user.apps handling

### DIFF
--- a/api/src/Session.php
+++ b/api/src/Session.php
@@ -965,7 +965,7 @@ class Session
 			// session only stores app-names, restore apps from egw_info[apps]
 			if (!is_array($GLOBALS['egw_info']['user']['apps']['api']))
 			{
-				$GLOBALS['egw_info']['user']['apps'] = array_intersect_key($GLOBALS['egw_info']['apps'], array_flip($GLOBALS['egw_info']['user']['apps']));
+				$GLOBALS['egw_info']['user']['apps'] = array_intersect_key($GLOBALS['egw_info']['apps'], $GLOBALS['egw_info']['user']['apps']);
 			}
 
 			// set prefs, they are no longer stored in session

--- a/api/src/Session.php
+++ b/api/src/Session.php
@@ -965,7 +965,25 @@ class Session
 			// session only stores app-names, restore apps from egw_info[apps]
 			if (!is_array($GLOBALS['egw_info']['user']['apps']['api']))
 			{
-				$GLOBALS['egw_info']['user']['apps'] = array_intersect_key($GLOBALS['egw_info']['apps'], $GLOBALS['egw_info']['user']['apps']);
+
+				// HOTFIX: handle GLOBALS.egw_info_user.apps properly.
+				//         when a non-egw user opens a series of share-urls 
+				//         the original array_flip()-code nukes
+                                $tmp_apps = [];
+                                if (isset($GLOBALS['egw_info']['user']['apps'][0])){
+                                        $app_keys = $GLOBALS['egw_info']['user']['apps'];
+                                } else {
+                                        $app_keys =  array_keys($GLOBALS['egw_info']['user']['apps']);
+                                }
+                                
+                                foreach( $app_keys as $idx=>$app_key){
+                                        if (isset($GLOBALS['egw_info']['apps'][$app_key])) {
+                                                $tmp_apps[$app_key] = $GLOBALS['egw_info']['apps'][$app_key];
+                                        }
+                                }
+                                
+                                $GLOBALS['egw_info']['user']['apps'] = $tmp_apps;
+
 			}
 
 			// set prefs, they are no longer stored in session


### PR DESCRIPTION
it looks like the if-branch on 966 enters multiple times because the "api"-array is not initialized or is missing. ie, the anonymous account has no access to api, but filemanager only. the egw_info.user.apps-array is initialized properly (with filemanager) during the first run, but it fails on subsequent calls, causing an exception and returning 401 to the user. the new code handles this situation and allows anonymous users to access the shared files without being asked for username&password by the browser.