### PR TITLE
Allow disabling calendar invitations to resources

### DIFF
--- a/calendar/inc/class.calendar_boupdate.inc.php
+++ b/calendar/inc/class.calendar_boupdate.inc.php
@@ -507,9 +507,18 @@ class calendar_boupdate extends calendar_bo
 	 */
 	public function check_acl_invite($uid)
 	{
-		if (!is_numeric($uid)) return true;	// nothing implemented for resources so far
-
-		if (!$this->require_acl_invite)
+		if (!is_numeric($uid))
+		{
+			$resources_config = Api\Config::read('resources');
+			if ($resources_config['bookingrequests'] === 'disabled') {
+				$ret = $this->check_perms(resources_acl_bo::DIRECT_BOOKING, 0, $uid);
+			}
+			else
+			{
+				$ret = true;
+			}
+		}
+		elseif (!$this->require_acl_invite)
 		{
 			$ret = true;	// no grant required
 		}

--- a/resources/templates/default/config.xet
+++ b/resources/templates/default/config.xet
@@ -18,6 +18,16 @@
 					</select>
 				</row>
 				<row>
+					<description value="Booking requests" span="all" class="subHeader"/>
+				</row>
+				<row>
+					<description value="Allow booking requests from any user when creating events?"/>
+					<select id="newsettings[bookingrequests]">
+						<option value="disabled">No, users will need to contact users with direct booking permission</option>
+						<option value="">Yes</option>
+					</select>
+				</row>
+				<row>
 					<description value="History logging" span="all" class="subHeader"/>
 				</row>
 				<row>


### PR DESCRIPTION
Hello,

in our organization, inventory requests are handled offline in-person, but we still want to use the resources management egroupware provides to track resource usage and availability.

This patch allows the administrator of an instance to disable invitations to resources by anyone who doesn't have the DIRECT_BOOKING privilege.

Let me know what you think.