### PR TITLE
Also Merge styles.xml in OpenOffice documents

### DIFF
--- a/api/src/Storage/Merge.php
+++ b/api/src/Storage/Merge.php
@@ -1698,6 +1698,7 @@ abstract class Merge
 				$archive = tempnam($GLOBALS['egw_info']['server']['temp_dir'], basename($document,$ext).'-').$ext;
 				copy($content_url,$archive);
 				$content_url = 'zip://'.$archive.'#'.($content_file = 'content.xml');
+				$styles_url = 'zip://'.$archive.'#'.($styles_file = 'styles.xml');
 				$this->parse_html_styles = true;
 				break;
 			case 'application/vnd.openxmlformats-officedocument.wordprocessingml.d':	// mimetypes in vfs are limited to 64 chars
@@ -1743,6 +1744,11 @@ abstract class Merge
 			//error_log(__METHOD__."() !this->merge() err=$err");
 			return $err;
 		}
+		if (!($merged_styles =& $this->merge($styles_url,$ids,$err,$mimetype,$fix)))
+		{
+			//error_log(__METHOD__."() !this->merge() err=$err");
+			return $err;
+		}
 		// Apply HTML formatting to target document, if possible
 		// check if we can use the XSL extension, to not give a fatal error and rendering whole merge-print non-functional
 		if (class_exists(XSLTProcessor) && class_exists(DOMDocument) && $this->parse_html_styles)
@@ -1750,6 +1756,7 @@ abstract class Merge
 			try
 			{
 				$this->apply_styles($merged, $mimetype);
+				$this->apply_styles($merged_styles, $mimetype);
 			}
 			catch (\Exception $e)
 			{
@@ -1788,6 +1795,7 @@ abstract class Merge
 				if ($zip->open($archive) !== true) throw new Api\Exception("!ZipArchive::open('$archive',|ZIPARCHIVE::CHECKCONS)");
 			}
 			if ($zip->addFromString($content_file,$merged) !== true) throw new Api\Exception("!ZipArchive::addFromString('$content_file',\$merged)");
+			if ($zip->addFromString($styles_file,$merged_styles) !== true) throw new Api\Exception("!ZipArchive::addFromString('$styles_file',\$merged)");
 			if ($zip->close() !== true) throw new Api\Exception("!ZipArchive::close()");
 			unset($zip);
 			unset($merged);


### PR DESCRIPTION
In an .odt document, you can add Text Frame fields, so the text is more organized and appears exactly where you want it.

This is especially useful when working with images in the same document, for example printing invoices.
See the attached file for an example
[text_frame_example.odt.zip](https://github.com/EGroupware/egroupware/files/2027317/text_frame_example.odt.zip)

The issue here, is that the text inside the Text Frames does not appear inside content.xml
Instead, it is stored in styles.xml

This means that the merging has to happen twice, once for each file.

This commit is more of a proof of concept than a complete solution. This setup works with the Text Frames mentioned above.

We just thought this could be addressed in a more sophisticated way, and not 'patchy' like this.