### PR TITLE
Move diff to server

### DIFF
--- a/api/js/etemplate/et2_widget_diff.js
+++ b/api/js/etemplate/et2_widget_diff.js
@@ -82,7 +82,7 @@ var et2_diff = (function(){ "use strict"; return et2_valueWidget.extend([et2_IDe
 		jQuery('<span class="ui-icon ui-icon-circle-plus">&nbsp;</span>')
 			.appendTo(self.div)
 			.css("cursor", "pointer")
-			.click({diff: view, div: self.div}, function(e) {
+			.click({diff: view, div: self.div, label: self.options.label}, function(e) {
 				var diff = e.data.diff;
 				var div = e.data.div;
 				self.un_minify(diff);
@@ -90,11 +90,18 @@ var et2_diff = (function(){ "use strict"; return et2_valueWidget.extend([et2_IDe
 					.append(diff);
 
 				dialog_div.dialog({
-					title: self.options.label,
+					title: e.data.label,
 					width: 'auto',
 					autoResize: true,
 					modal: true,
 					buttons: [{text: self.egw().lang('ok'), click: function() {jQuery(this).dialog("close");}}],
+					open: function() {
+						if(jQuery(this).parent().height() > jQuery(window).height())
+						{
+							jQuery(this).height(jQuery(window).height() *0.7);
+						}
+						jQuery(this).dialog({position: "center"});
+					},
 					close: function(event, ui) {
 						// Need to destroy the dialog, etemplate widget needs divs back where they were
 						dialog_div.dialog("destroy");

--- a/api/js/etemplate/et2_widget_diff.js
+++ b/api/js/etemplate/et2_widget_diff.js
@@ -47,7 +47,7 @@ var et2_diff = (function(){ "use strict"; return et2_valueWidget.extend([et2_IDe
 		// included via etemplate2.css
 		//this.egw().includeCSS('../../../vendor/bower-asset/dist/dist2html.css');
 		this.div = document.createElement("div");
-		jQuery(this.div).addClass('diff');
+		jQuery(this.div).addClass('et2_diff');
 	},
 
 	set_value: function(value) {
@@ -100,7 +100,7 @@ var et2_diff = (function(){ "use strict"; return et2_valueWidget.extend([et2_IDe
 						{
 							jQuery(this).height(jQuery(window).height() *0.7);
 						}
-						jQuery(this).dialog({position: "center"});
+						jQuery(this).addClass('et2_diff').dialog({position: "center"});
 					},
 					close: function(event, ui) {
 						// Need to destroy the dialog, etemplate widget needs divs back where they were

--- a/api/js/etemplate/et2_widget_diff.js
+++ b/api/js/etemplate/et2_widget_diff.js
@@ -13,8 +13,8 @@
 /*egw:uses
 	/vendor/bower-asset/jquery/dist/jquery.js;
 	/vendor/bower-asset/jquery-ui/jquery-ui.js;
-	lib/jsdifflib/difflib;
-	lib/jsdifflib/diffview;
+	/vendor/bower-asset/diff2html/dist/diff2html.min.js;
+	/vendor/bower-asset/diff2html/dist/diff2html-ui.min.js;
 	et2_core_valueWidget;
 */
 
@@ -29,6 +29,11 @@ var et2_diff = (function(){ "use strict"; return et2_valueWidget.extend([et2_IDe
 		"value": {
 			"type": "any"
 		}
+	},
+
+	diff_options: {
+		"inputFormat":"diff",
+		"matching": "words"
 	},
 
 	/**
@@ -48,51 +53,13 @@ var et2_diff = (function(){ "use strict"; return et2_valueWidget.extend([et2_IDe
 
 	set_value: function(value) {
 		jQuery(this.div).empty();
-		if(typeof value['old'] == 'string' && typeof value['new'] == 'string') {
-			// Build diff
-			var old_text = difflib.stringAsLines(value['old'].toString());
-			var new_text = difflib.stringAsLines(value['new'].toString());
-			var sm = new difflib.SequenceMatcher(old_text, new_text);
-			var opcodes = sm.get_opcodes();
-			var view = diffview.buildView({
-				baseTextLines: old_text,
-				newTextLines: new_text,
-				opcodes: opcodes,
-				baseTextName: '',//this.egw().lang('Old value'),
-				newTextName: '',//this.egw().lang('New value'),
-				viewType: 1
-			});
-			jQuery(this.div).append(view);
-			if(this.mini) {
-				view = jQuery(view);
-				this.minify(view);
-				var self = this;
-				jQuery('<span class="ui-icon ui-icon-circle-plus">&nbsp;</span>')
-					.appendTo(self.div)
-					.css("cursor", "pointer")
-					.click({diff: view, div: self.div}, function(e) {
-						var diff = e.data.diff;
-						var div = e.data.div;
-						self.un_minify(diff);
-						var dialog_div = jQuery('<div>')
-							.append(diff);
-						dialog_div.dialog({
-							title: self.options.label,
-							width: 'auto',
-							autoResize: true,
-							modal: true,
-							buttons: [{text: self.egw().lang('ok'), click: function() {jQuery(this).dialog("close");}}],
-							close: function(event, ui) {
-								// Need to destroy the dialog, etemplate widget needs divs back where they were
-								dialog_div.dialog("destroy");
-								self.minify(this);
-
-								// Put it back where it came from, or et2 will error when clear() is called
-								diff.prependTo(div);
-							}
-						});
-					});
-			}
+		if(typeof value == 'string') {
+			jQuery(this.div).append(
+					Diff2Html.getPrettyHtml(
+						value,
+						this.diff_options
+					)
+			);
 		}
 		else if(typeof value != 'object')
 		{

--- a/api/js/etemplate/et2_widget_diff.js
+++ b/api/js/etemplate/et2_widget_diff.js
@@ -14,7 +14,6 @@
 	/vendor/bower-asset/jquery/dist/jquery.js;
 	/vendor/bower-asset/jquery-ui/jquery-ui.js;
 	/vendor/bower-asset/diff2html/dist/diff2html.min.js;
-	/vendor/bower-asset/diff2html/dist/diff2html-ui.min.js;
 	et2_core_valueWidget;
 */
 
@@ -46,7 +45,7 @@ var et2_diff = (function(){ "use strict"; return et2_valueWidget.extend([et2_IDe
 		this.mini = true;
 
 		// included via etemplate2.css
-		//this.egw().includeCSS('etemplate/js/lib/jsdifflib/diffview.css');
+		//this.egw().includeCSS('../../../vendor/bower-asset/dist/dist2html.css');
 		this.div = document.createElement("div");
 		jQuery(this.div).addClass('diff');
 	},
@@ -54,19 +53,59 @@ var et2_diff = (function(){ "use strict"; return et2_valueWidget.extend([et2_IDe
 	set_value: function(value) {
 		jQuery(this.div).empty();
 		if(typeof value == 'string') {
-			jQuery(this.div).append(
-					Diff2Html.getPrettyHtml(
-						value,
-						this.diff_options
-					)
-			);
+
+			// Diff2Html likes to have files, we don't have them
+			if(value.indexOf('---') !== 0)
+			{
+				value = "--- diff\n+++ diff\n"+value;
+			}
+			var diff = Diff2Html.getPrettyHtml(value, this.diff_options);
+		//	var ui = new Diff2HtmlUI({diff: diff});
+		//	ui.draw(jQuery(this.div), this.diff_options);
+			jQuery(this.div).append(diff);
 		}
 		else if(typeof value != 'object')
 		{
 			jQuery(this.div).append(value);
 		}
+		this.check_mini();
 	},
 
+	check_mini: function() {
+		if(!this.mini)
+		{
+			return false;
+		}
+		var view = jQuery(this.div).children();
+		this.minify(view);
+		var self = this;
+		jQuery('<span class="ui-icon ui-icon-circle-plus">&nbsp;</span>')
+			.appendTo(self.div)
+			.css("cursor", "pointer")
+			.click({diff: view, div: self.div}, function(e) {
+				var diff = e.data.diff;
+				var div = e.data.div;
+				self.un_minify(diff);
+				var dialog_div = jQuery('<div>')
+					.append(diff);
+
+				dialog_div.dialog({
+					title: self.options.label,
+					width: 'auto',
+					autoResize: true,
+					modal: true,
+					buttons: [{text: self.egw().lang('ok'), click: function() {jQuery(this).dialog("close");}}],
+					close: function(event, ui) {
+						// Need to destroy the dialog, etemplate widget needs divs back where they were
+						dialog_div.dialog("destroy");
+						self.minify(this);
+
+						// Put it back where it came from, or et2 will error when clear() is called
+						diff.prependTo(div);
+					}
+				});
+			});
+	},
 	set_label: function(_label) {
 		this.options.label = _label;
 

--- a/api/js/etemplate/et2_widget_historylog.js
+++ b/api/js/etemplate/et2_widget_historylog.js
@@ -500,19 +500,11 @@ var et2_historylog = (function(){ "use strict"; return et2_valueWidget.extend([e
 			{
 				// Large text value - span both columns, and show a nice diff
 				var jthis = jQuery(this);
-				if(i == self.NEW_VALUE)
+				if(i === self.NEW_VALUE)
 				{
 					// Diff widget
 					widget = self.diff.widget;
 					nodes = self.diff.nodes.clone();
-
-					if (typeof _data[self.columns[self.NEW_VALUE].id] == "string")
-					{
-						value = _data[self.columns[i].id] = {
-							'old': _data[self.columns[i+1].id],
-							'new': value
-						};
-					}
 
 					// Skip column 4
 					jthis.parents("td").attr("colspan", 2)
@@ -571,7 +563,7 @@ var et2_historylog = (function(){ "use strict"; return et2_valueWidget.extend([e
 			this.egw().debug("warn", "Crazy diff value", value);
 			return false;
 		}
-		return columnName == 'note' || columnName == 'description' || (value && (value.length > 50 || value.match(/\n/g)));
+		return value=== '***diff***';
 	},
 
 	resize: function (_height)

--- a/api/js/etemplate/et2_widget_historylog.js
+++ b/api/js/etemplate/et2_widget_historylog.js
@@ -474,8 +474,8 @@ var et2_historylog = (function(){ "use strict"; return et2_valueWidget.extend([e
 				value = _data['share_email'];
 			}
 			// Get widget from list, unless it needs a diff widget
-			if(typeof widget == 'undefined' && typeof self.fields[_data.status] != 'undefined' && i < self.NEW_VALUE ||
-					i >= self.NEW_VALUE &&!self._needsDiffWidget(_data['status'], _data[self.columns[self.OLD_VALUE].id]))
+			if(typeof widget == 'undefined' && typeof self.fields[_data.status] != 'undefined' && (i < self.NEW_VALUE ||
+					i >= self.NEW_VALUE &&!self._needsDiffWidget(_data['status'], _data[self.columns[self.OLD_VALUE].id])))
 			{
 				widget = self.fields[_data.status].widget;
 				if(!widget._children.length)

--- a/api/js/etemplate/et2_widget_historylog.js
+++ b/api/js/etemplate/et2_widget_historylog.js
@@ -592,7 +592,7 @@ var et2_historylog = (function(){ "use strict"; return et2_valueWidget.extend([e
 		if(this.dataview)
 		{
 			var columns = this.dataview.getColumnMgr().columnWidths;
-			jQuery('.diff', this.div).parent().width(columns[this.NEW_VALUE] + columns[this.OLD_VALUE]);
+			jQuery('.et2_diff', this.div).parent().width(columns[this.NEW_VALUE] + columns[this.OLD_VALUE]);
 		}
 	}
 });}).call(this);

--- a/api/js/etemplate/et2_widget_historylog.js
+++ b/api/js/etemplate/et2_widget_historylog.js
@@ -473,7 +473,9 @@ var et2_historylog = (function(){ "use strict"; return et2_valueWidget.extend([e
 				widget = undefined;
 				value = _data['share_email'];
 			}
-			if(typeof widget == 'undefined' && typeof self.fields[_data.status] != 'undefined')
+			// Get widget from list, unless it needs a diff widget
+			if(typeof widget == 'undefined' && typeof self.fields[_data.status] != 'undefined' && i < self.NEW_VALUE ||
+					i >= self.NEW_VALUE &&!self._needsDiffWidget(_data['status'], _data[self.columns[self.OLD_VALUE].id]))
 			{
 				widget = self.fields[_data.status].widget;
 				if(!widget._children.length)
@@ -585,6 +587,12 @@ var et2_historylog = (function(){ "use strict"; return et2_valueWidget.extend([e
 				// in order to update the height with new value
 				this.div.trigger('resize.' +this.options.value.app + this.options.value.id);
 			}
+		}
+		// Resize diff widgets to match new space
+		if(this.dataview)
+		{
+			var columns = this.dataview.getColumnMgr().columnWidths;
+			jQuery('.diff', this.div).parent().width(columns[this.NEW_VALUE] + columns[this.OLD_VALUE]);
 		}
 	}
 });}).call(this);

--- a/api/setup/setup.inc.php
+++ b/api/setup/setup.inc.php
@@ -11,7 +11,7 @@
 /* Basic information about this app */
 $setup_info['api']['name']      = 'api';
 $setup_info['api']['title']     = 'EGroupware API';
-$setup_info['api']['version']   = '17.1.005';
+$setup_info['api']['version']   = '17.1.006';
 $setup_info['api']['versions']['current_header'] = '1.29';
 // maintenance release in sync with changelog in doc/rpm-build/debian.changes
 $setup_info['api']['versions']['maintenance_release'] = '17.1.20190222';

--- a/api/src/Storage/History.php
+++ b/api/src/Storage/History.php
@@ -266,7 +266,7 @@ class History
 			))
 			{
 				// Larger text stored with full old / new value - calculate diff and just send that
-				$diff = new \Text_Diff('auto', array(explode("\n",$row['history_new_value']), explode("\n",$row['history_old_value'])));
+				$diff = new \Text_Diff('auto', array(explode("\n",$row['history_old_value']), explode("\n",$row['history_new_value'])));
 				$renderer = new \Text_Diff_Renderer_unified();
 				$row['history_new_value'] = $renderer->render($diff);
 				$row['history_old_value'] = Tracking::DIFF_MARKER;

--- a/api/src/Storage/History.php
+++ b/api/src/Storage/History.php
@@ -266,8 +266,8 @@ class History
 			))
 			{
 				// Larger text stored with full old / new value - calculate diff and just send that
-				$diff = new \Text_Diff('auto', array(explode("\n",$row['history_old_value']), explode("\n",$row['history_new_value'])));
-				$renderer = new \Text_Diff_Renderer_unified();
+				$diff = new \Horde_Text_Diff('auto', array(explode("\n",$row['history_old_value']), explode("\n",$row['history_new_value'])));
+				$renderer = new \Horde_Text_Diff_Renderer_Unified();
 				$row['history_new_value'] = $renderer->render($diff);
 				$row['history_old_value'] = Tracking::DIFF_MARKER;
 			}

--- a/api/src/Storage/History.php
+++ b/api/src/Storage/History.php
@@ -311,7 +311,9 @@ class History
 
 	protected static function needs_diff($name, $value)
 	{
-		return $name == 'note' || $name == 'description' ||
-			($value && (strlen($value) > 50 || strstr($value, "\n") !== FALSE));
+		return $name == 'note' ||	// Addressbook
+			strpos($name, 'description') !== false ||	// Calendar, Records, Timesheet, ProjectManager, Resources
+			$name == 'De' ||	// Tracker, InfoLog
+			($value && (strlen($value) > 200 || strstr($value, "\n") !== FALSE));
 	}
 }

--- a/api/src/Storage/History.php
+++ b/api/src/Storage/History.php
@@ -261,8 +261,8 @@ class History
 				}
 			}
 			if ($row['history_old_value'] !== Tracking::DIFF_MARKER && (
-				$this->needs_diff($row['history_status'], $row['history_old_value']) ||
-				$this->needs_diff($row['history_status'], $row['history_old_value'])
+				static::needs_diff($row['history_status'], $row['history_old_value']) ||
+				static::needs_diff($row['history_status'], $row['history_old_value'])
 			))
 			{
 				// Larger text stored with full old / new value - calculate diff and just send that
@@ -309,7 +309,7 @@ class History
 		return $total;
 	}
 
-	protected function needs_diff($name, $value)
+	protected static function needs_diff($name, $value)
 	{
 		return $name == 'note' || $name == 'description' ||
 			($value && (strlen($value) > 50 || strstr($value, "\n") !== FALSE));

--- a/api/src/Storage/Tracking.php
+++ b/api/src/Storage/Tracking.php
@@ -463,7 +463,7 @@ abstract class Tracking
 					strpos($data[$name], PHP_EOL) !== FALSE || strpos($old[$name], PHP_EOL) !== FALSE))
 			{
 				// Multiline string, just store diff
-				$diff = new \Text_Diff('auto', array(explode("\n",$data[$name]), explode("\n",$old[$name])));
+				$diff = new \Text_Diff('auto', array(explode("\n",$old[$name]), explode("\n",$data[$name])));
 				$renderer = new \Text_Diff_Renderer_unified();
 				$this->historylog->add(
 					$status,

--- a/api/src/Storage/Tracking.php
+++ b/api/src/Storage/Tracking.php
@@ -18,7 +18,6 @@ use EGroupware\Api;
 // explicitly reference classes still in phpgwapi or otherwise outside api
 use notifications;
 
-use Text_Diff_Renderer_unified;
 
 /**
  * Abstract base class for trackering:
@@ -463,8 +462,8 @@ abstract class Tracking
 					strpos($data[$name], PHP_EOL) !== FALSE || strpos($old[$name], PHP_EOL) !== FALSE))
 			{
 				// Multiline string, just store diff
-				$diff = new \Text_Diff('auto', array(explode("\n",$old[$name]), explode("\n",$data[$name])));
-				$renderer = new \Text_Diff_Renderer_unified();
+				$diff = new \Horde_Text_Diff('auto', array(explode("\n",$old[$name]), explode("\n",$data[$name])));
+				$renderer = new \Horde_Text_Diff_Renderer_Unified();
 				$this->historylog->add(
 					$status,
 					$data[$this->id_field],

--- a/api/src/Storage/Tracking.php
+++ b/api/src/Storage/Tracking.php
@@ -192,6 +192,12 @@ abstract class Tracking
 	const ONE2N_SEPERATOR = '~|~';
 
 	/**
+	 * Marker for change stored as unified diff, not old/new value
+	 * Diff is in the new value, marker in old value
+	 */
+	const DIFF_MARKER = '***diff***';
+
+	/**
 	 * Config name for custom notification message
 	 */
 	const CUSTOM_NOTIFICATION = 'custom_notification';
@@ -463,7 +469,7 @@ abstract class Tracking
 					$status,
 					$data[$this->id_field],
 					$renderer->render($diff),
-					'***diff***'
+					self::DIFF_MARKER
 				);
 			}
 			else

--- a/api/src/Storage/Tracking.php
+++ b/api/src/Storage/Tracking.php
@@ -18,6 +18,8 @@ use EGroupware\Api;
 // explicitly reference classes still in phpgwapi or otherwise outside api
 use notifications;
 
+use Text_Diff_Renderer_unified;
+
 /**
  * Abstract base class for trackering:
  *  - logging all modifications of an entry
@@ -450,6 +452,19 @@ abstract class Tracking
 					//error_log(__METHOD__."() $i: historylog->add('$name',data['$this->id_field']={$data[$this->id_field]},".array2string($added[$i]).','.array2string($removed[$i]));
 					$this->historylog->add($name,$data[$this->id_field],$added[$i],$removed[$i]);
 				}
+			}
+			else if (is_string($data[$name]) && is_string($old[$name]) && (
+					strpos($data[$name], PHP_EOL) !== FALSE || strpos($old[$name], PHP_EOL) !== FALSE))
+			{
+				// Multiline string, just store diff
+				$diff = new \Text_Diff('auto', array(explode("\n",$data[$name]), explode("\n",$old[$name])));
+				$renderer = new \Text_Diff_Renderer_unified();
+				$this->historylog->add(
+					$status,
+					$data[$this->id_field],
+					$renderer->render($diff),
+					'***diff***'
+				);
 			}
 			else
 			{

--- a/api/templates/default/etemplate2.css
+++ b/api/templates/default/etemplate2.css
@@ -13,7 +13,7 @@
 /*@import url("../../js/jquery/blueimp/css/blueimp-gallery.min.css");*/
 /*@import url("../../js/dhtmlxtree/codebase/dhtmlxtree.css");*/
 /*@import url("../../js/egw_action/test/skins/dhtmlxmenu_egw.css");*/
-/*@import url("../../js/etemplate/lib/jsdifflib/diffview.css");*/
+/*@import url("../../../vendor/bower-asset/diff2html/dist/diff2html.css");*/
 /*@import url("../../../vendor/bower-asset/cropper/dist/cropper.min.css");*/
 /*@import url("css/flags.css");*/
 /*@import url("css/htmlarea.css");*/
@@ -567,9 +567,27 @@ for printing
 /**
  * Diff widget
  */
+div.diff {
+	width: 100%;
+}
 .diff thead,
-.author {
+.author,
+.d2h-file-header,
+.d2h-file-info,
+.d2h-info,
+.diff .d2h-cntx
+{
   display: none;
+}
+.d2h-file-diff {
+	white-space:normal;
+}
+.diff .d2h-file-diff {
+	overflow-x: hidden;
+}
+.ui-widget-content .d2h-file-diff {
+	overflow-x: visible;
+	overflow-y: visible;
 }
 .diff .ui-icon {
   margin-top: -16px;

--- a/api/templates/default/etemplate2.css
+++ b/api/templates/default/etemplate2.css
@@ -585,6 +585,9 @@ div.diff {
 .diff .d2h-file-diff {
 	overflow-x: hidden;
 }
+.ui-widget-content .d2h-code-line-ctn {
+	white-space:normal;
+}
 .ui-widget-content .d2h-file-diff {
 	overflow-x: visible;
 	overflow-y: visible;

--- a/api/templates/default/etemplate2.css
+++ b/api/templates/default/etemplate2.css
@@ -567,22 +567,22 @@ for printing
 /**
  * Diff widget
  */
-div.diff {
+div.et2_diff {
 	width: 100%;
 }
-.diff thead,
+.et2_diff thead,
 .author,
 .d2h-file-header,
 .d2h-file-info,
 .d2h-info,
-.diff .d2h-cntx
+.et2_diff .d2h-cntx
 {
   display: none;
 }
 .d2h-file-diff {
 	white-space:normal;
 }
-.diff .d2h-file-diff {
+.et2_diff .d2h-file-diff {
 	overflow-x: hidden;
 }
 .ui-widget-content .d2h-code-line-ctn {
@@ -592,10 +592,23 @@ div.diff {
 	overflow-x: visible;
 	overflow-y: visible;
 }
-.diff .ui-icon {
+.et2_diff .ui-icon {
   margin-top: -16px;
   float: right;
 }
+.et2_diff .d2h-del, .et2_diff.d2h-del.d2h-change, .et2_diff .d2h-file-diff .d2h-del.d2h-change  {
+	background-color: #ffeef0;
+}
+.et2_diff .d2h-code-line del, .et2_diff .d2h-code-side-line del {
+	background-color: #fdb8c0;
+}
+.et2_diff .d2h-ins, .et2_diff.d2h-ins.d2h-change, .et2_diff .d2h-file-diff .d2h-ins.d2h-change {
+	background-color: #e6ffed;
+}
+.et2_diff .d2h-code-line ins, .et2_diff .d2h-code-side-line ins {
+	background-color: #acf2bd;
+}
+
 /** Display a loading icon **/
 .loading {
   background-position: center;

--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,8 @@
 		"egroupware/tracker": "self.version",
 		"egroupware/z-push-dev": "self.version",
 		"egroupware/activesync": "self.version",
-		"egroupware/adodb-php": "self.version"
+		"egroupware/adodb-php": "self.version",
+		"pear-pear.horde.org/Horde_Text_Diff": "^2.2"
 	},
 	"require-dev": {
 	},

--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,8 @@
 		"egroupware/z-push-dev": "self.version",
 		"egroupware/activesync": "self.version",
 		"egroupware/adodb-php": "self.version",
-		"pear-pear.horde.org/Horde_Text_Diff": "^2.2"
+		"pear-pear.horde.org/Horde_Text_Diff": "^2.2",
+		"bower-asset/diff2html": "^2.7"
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
Instead of storing old/new values for longer text fields and sending them to the client for historylog, we now store just the diff as new value with '***diff***' as the old value.
An update script will convert existing values.