### PR TITLE
Fixed, PHP Warning: Invalid argument supplied for foreach() in ...

### DIFF
--- a/api/src/Db/Schema.php
+++ b/api/src/Db/Schema.php
@@ -165,16 +165,22 @@ class Schema
 			$columns = implode('-',$columns);
 			if ($ignore_length_limit) $columns = preg_replace('/\(\d+\)/', '', $columns);
 		}
-		foreach($indexs as $index)
-		{
-			if (is_array($index))
+		
+		if(is_array($indexs)){
+
+			foreach($indexs as $index)
 			{
-				unset($index['options']);
-				$index = implode('-',$index);
+				if (is_array($index))
+				{
+					unset($index['options']);
+					$index = implode('-',$index);
+				}
+				if ($ignore_length_limit) $index = preg_replace('/\(\d+\)/', '', $index);
+				if ($columns == $index) return true;
 			}
-			if ($ignore_length_limit) $index = preg_replace('/\(\d+\)/', '', $index);
-			if ($columns == $index) return true;
+
 		}
+
 		return false;
 	}
 

--- a/importexport/inc/class.importexport_definition.inc.php
+++ b/importexport/inc/class.importexport_definition.inc.php
@@ -180,11 +180,16 @@ class importexport_definition implements importexport_iface_egw_record {
 	 */
 	private function set_options(array $_plugin_options) {
 		// Check conditions
-		foreach ( $_plugin_options['conditions'] as $key => $condition ) {
-			if(!$condition['string'])
-			{
-				unset($_plugin_options['conditions'][$key]);
+
+		if (is_array($_plugin_options['conditions'] )){
+		
+			foreach ( $_plugin_options['conditions'] as $key => $condition ) {
+				if(!$condition['string'])
+				{
+					unset($_plugin_options['conditions'][$key]);
+				}
 			}
+
 		}
 		$this->definition['plugin_options'] = $_plugin_options;
 	}


### PR DESCRIPTION
On standard install messages like the following show up in the Server log:

===== 1 =====
PHP Warning: Invalid argument supplied for foreach() in .../html/egw/api/src/Db/Schema.php on line 170
PHP message: #1 .../html/egw/api/src/Db/Schema.php(566): EGroupware\Api\Db\Schema->_in_index('pm_id', NULL, true)
PHP message: #2 /home/asig/dev/egw/egwdev2/html/egw/api/src/Db/Schema.php(275): EGroupware\Api\Db\Schema->CreateIndex('egw_pm_roles', 'pm_id', false, Array, 'egw_pm_roles_id')
PHP message: #3 /home/asig/dev/egw/egwdev2/html/egw/api/src/Db/Schema.php(828): EGroupware\Api\Db\Schema->CreateTable('egw_pm_roles', Array)
PHP message: #4 /home/asig/dev/egw/egwdev2/html/egw/setup/inc/class.setup_process.inc.php(753): EGroupware\Api\Db\Schema->ExecuteScripts(Array, NULL)
PHP message: #5 /home/asig/dev/egw/egwdev2/html/egw/setup/inc/class.setup_process.inc.php(422): setup_process->post_process(Array, NULL)
PHP message: #6 /home/asig/dev/egw/egwdev2/html/egw/setup/inc/class.setup_process.inc.php(147): setup_process->current(Array, NULL)
PHP message: #7 /home/asig/dev/egw/egwdev2/html/egw/setup/index.php(349): setup_process->pass(Array, 'new', NULL, NULL)
PHP message: #8 {main}


==== 2 =====

PHP message: PHP Warning: Invalid argument supplied for foreach() in .../html/egw/importexport/inc/class.importexport_definition.inc.php on line 184
PHP message: #..../html/egw/importexport/inc/class.importexport_definition.inc.php(257): importexport_definition->set_options(Array)
PHP message: #2.../html/egw/importexport/inc/class.importexport_definitions_bo.inc.php(254): importexport_definition->set_record(Array)
PHP message: #3 .../html/egw/importexport/setup/default_records.inc.php(34): importexport_definitions_bo::import('/home/asig/dev/...')
PHP message: #4 ..../html/egw/setup/inc/class.setup_process.inc.php(503): include('/home/asig/dev/...')
PHP message: #5 .../html/egw/setup/inc/class.setup_process.inc.php(149): setup_pr
