### PR TITLE
Fixed, PHP Warning: Invalid argument supplied for foreach(), cast array

### DIFF
--- a/filemanager/inc/class.filemanager_hooks.inc.php
+++ b/filemanager/inc/class.filemanager_hooks.inc.php
@@ -236,15 +236,21 @@ class filemanager_hooks
 		}
 		$editorLink = self::getEditorLink();
 		$mimes = array();
-		foreach ($editorLink['mime'] as $mime => $value)
-		{
-			$mimes[$mime] = lang('%1 file', strtoupper($value['ext'])).' ('.$mime.')';
 
-			if (!empty($value['extra_extensions']))
+		if (is_array($editorLink['mime'])){
+
+			foreach ($editorLink['mime'] as $mime => $value)
 			{
-				$mimes[$mime] .= ', '.strtoupper(implode(', ', $value['extra_extensions']));
+				$mimes[$mime] = lang('%1 file', strtoupper($value['ext'])).' ('.$mime.')';
+
+				if (!empty($value['extra_extensions']))
+				{
+					$mimes[$mime] .= ', '.strtoupper(implode(', ', $value['extra_extensions']));
+				}
 			}
+
 		}
+
 		asort($mimes);
 		$settings += array (
 			'sections.2' => array(

--- a/filemanager/inc/class.filemanager_hooks.inc.php
+++ b/filemanager/inc/class.filemanager_hooks.inc.php
@@ -237,9 +237,8 @@ class filemanager_hooks
 		$editorLink = self::getEditorLink();
 		$mimes = array();
 
-		if (is_array($editorLink['mime'])){
 
-			foreach ($editorLink['mime'] as $mime => $value)
+			foreach ((array)$editorLink['mime'] as $mime => $value)
 			{
 				$mimes[$mime] = lang('%1 file', strtoupper($value['ext'])).' ('.$mime.')';
 
@@ -248,8 +247,6 @@ class filemanager_hooks
 					$mimes[$mime] .= ', '.strtoupper(implode(', ', $value['extra_extensions']));
 				}
 			}
-
-		}
 
 		asort($mimes);
 		$settings += array (


### PR DESCRIPTION
Error message during setup:

2019/03/05 22:12:42 [error] 1276#1276: *36 FastCGI sent in stderr: "PHP message: PHP Warning: Invalid argument supplied for foreach() in /home/asig/dev/egw/egwdev2/html/egw/filemanager/inc/class.filemanager_hooks.inc.php on line 237
PHP message: #1 /home/asig/dev/egw/egwdev2/html/egw/api/src/loader/deprecated_factory.php(179): filemanager_hooks::settings(Array)
PHP message: #2 /home/asig/dev/egw/egwdev2/html/egw/setup/inc/class.setup.inc.php(719): ExecMethod('filemanager_hoo...', Array)
PHP message: #3 /home/asig/dev/egw/egwdev2/html/egw/setup/inc/class.setup_process.inc.php(463): setup->set_default_preferences('filemanager')
PHP message: #4 /home/asig/dev/egw/egwdev2/html/egw/setup/inc/class.setup_process.inc.php(147): setup_process->current(Array, NULL)
PHP message: #5 /home/asig/dev/egw/egwdev2/html/egw/setup/index.php(349): setup_process->pass(Array, 'new', NULL, NULL)
PHP message: #6 {main}