### PR TITLE
Contact/Storage, Set $grants by default as an empty array

### DIFF
--- a/api/src/Contacts/Storage.php
+++ b/api/src/Contacts/Storage.php
@@ -102,7 +102,7 @@ class Storage
 	 *
 	 * @var array
 	 */
-	var $grants;
+	var $grants = array();
 
 	/**
 	 *  userid of current user


### PR DESCRIPTION
When you call:

 $ui = new addressbook_ui();
 $groups = $ui->get_addressbooks(Acl::ADD);

in the settings hook of a custom application you get the following warning during setup "install all applications":

2019/03/06 07:50:58 [error] 1276#1276: *279 FastCGI sent in stderr: "PHP message: PHP Warning: Invalid argument supplied for foreach() in /home/asig/dev/egw/egwdev2/html/egw/api/src/Contacts.php on line 373
PHP message: #1 /home/asig/dev/egw/egwdev2/html/egw/actele/inc/class.actele_hooks.inc.php(63): EGroupware\Api\Contacts->get_addressbooks(2)
PHP message: #2 /home/asig/dev/egw/egwdev2/html/egw/api/src/loader/deprecated_factory.php(179): actele_hooks::settings(Array)
PHP message: #3 /home/asig/dev/egw/egwdev2/html/egw/setup/inc/class.setup.inc.php(719): ExecMethod('actele_hooks::s...', Array)
PHP message: #4 /home/asig/dev/egw/egwdev2/html/egw/setup/inc/class.setup_process.inc.php(432): setup->set_default_preferences('actele')
PHP message: #5 /home/asig/dev/egw/egwdev2/html/egw/setup/inc/class.setup_process.inc.php(147): setup_process->current(Array, NULL)
PHP message: #6 /home/asig/dev/egw/egwdev2/html/egw/setup/index.php(349): setup_process->pass(Array, 'new', NULL, NULL)
PHP message: #7 {main}


