### PR TITLE
Add reply to for email notification

### DIFF
--- a/api/src/Storage/Tracking.php
+++ b/api/src/Storage/Tracking.php
@@ -304,6 +304,7 @@ abstract class Tracking
 	 *  - 'subject' string subject line for the notification of $data,$old, defaults to link-title
 	 *  - 'link' string of link to view $data
 	 *  - 'sender' sender of email
+	 *  - 'reply_to' reply to of email
 	 *  - 'skip_notify' array of email addresses that should _not_ be notified
 	 *  - CUSTOM_NOTIFICATION string notification body message.  Merge print placeholders are allowed.
 	 * @param array $data current entry
@@ -787,6 +788,7 @@ abstract class Tracking
 
 			// get rest of notification message
 			$sender = $this->get_sender($data,$old,true,$receiver);
+			$reply_to = $this->get_reply_to($data,$old);
 			$subject = $this->get_subject($data,$old,$deleted,$receiver);
 			$link = $this->get_notification_link($data,$old,$receiver);
 			$attachments = $this->get_attachments($data,$old,$receiver);
@@ -825,6 +827,7 @@ abstract class Tracking
 				$body_cache['html'] = "<span style='display:none;'>-----".lang('original message')."-----</span>"."\r\n".$body_cache['html'];
 				$notification->set_message($body_cache['html'], 'html');
 				$notification->set_sender($sender);
+				$notification->set_reply_to($reply_to);
 				$notification->set_subject($subject);
 				$notification->set_links(array($link));
 				$notification->set_popupdata($link['app'], $link);
@@ -913,6 +916,23 @@ abstract class Tracking
 		}
 		//echo "<p>".__METHOD__."()='".htmlspecialchars($sender)."'</p>\n";
 		return $sender;
+	}
+
+	/**
+	 * Get reply to address
+	 *
+	 * The default implementation prefers depending on what is returned by get_config('reply_to').
+	 *
+	 * @param int $user account_lid of user
+	 * @param array $data
+	 * @param array $old
+	 * @return string or null
+	 */
+	protected function get_reply_to($data,$old)
+	{
+		$reply_to = $this->get_config('reply_to',$data,$old);
+		
+		return $reply_to;
 	}
 
 	/**

--- a/notifications/inc/class.notifications.inc.php
+++ b/notifications/inc/class.notifications.inc.php
@@ -113,6 +113,12 @@ class notifications {
 	protected $sender;
 
 	/**
+	 * email address for reply to
+	 * @var string
+	 */
+	protected $reply_to;
+
+	/**
 	 * holds notification subject
 	 * @var string
 	 */
@@ -227,6 +233,16 @@ class notifications {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Set reply_to for the current notification
+	 *
+	 * @param $_reply_to string for email address to reply to
+	 */
+	public function set_reply_to($_reply_to) {
+		$this->reply_to = $_reply_to;
+		return true;
 	}
 
 	/**
@@ -550,6 +566,8 @@ class notifications {
 							if (!empty($this->popupsubject)) $lsubject = $this->popupsubject;
 							if ($this->popup_links) $llinks = $this->popup_links;
 							if (is_array($this->popup_data)) $popup_data = $this->popup_data;
+						} elseif ($backend == 'email') {
+							if (!empty($this->reply_to)) $popup_data = array( 'reply_to' => $this->reply_to );
 						}
 						$obj->send($this->prepend_message($messages, $prepend_message), $lsubject, $llinks, $this->attachments, $popup_data);
 

--- a/notifications/inc/class.notifications_email.inc.php
+++ b/notifications/inc/class.notifications_email.inc.php
@@ -90,8 +90,6 @@ class notifications_email implements notifications_iface {
 	 */
 	public function send(array $_messages, $_subject = false, $_links = false, $_attachments = false, $_data = false)
 	{
-		unset ($_data);
-
 		$body_plain = $_messages['plain'].$this->render_links($_links, false, $this->preferences->external_mailclient);
 		$body_html = "<html><body>\n".$_messages['html'].$this->render_links($_links, true, $this->preferences->external_mailclient)."</body>\n</html>\n";
 
@@ -105,6 +103,10 @@ class notifications_email implements notifications_iface {
 		//error_log(__METHOD__.__LINE__."preparing notification message via email.".array2string($this->mail));
 
 		$this->mail->setFrom($this->sender->account_email, $this->sender->account_fullname);
+
+		if ( $_data && isset( $_data['reply_to'] ) ) {
+			$this->mail->addAddress($_data['reply_to'], '', 'replyto');
+		}
 
 		$this->mail->addHeader('Subject', trim($_subject)); // trim the subject to avoid strange wrong encoding problem
 		if ($_messages['html'])


### PR DESCRIPTION
For notifications from the Tracker it will be able to indicate email address should be answered. This will allow you to reply to the Tracker when the sender of the message is a user of eGroupware.

Requires adding a parameter in the configuration of the Tracker.