### PR TITLE
Fixed typo in Mail.php getStructure $uid -> $_uid (in some cases i.e.…

### DIFF
--- a/api/src/Mail.php
+++ b/api/src/Mail.php
@@ -5646,8 +5646,13 @@ class Mail
 			$_folder = ($this->sessionData['mailbox']? $this->sessionData['mailbox'] : $this->icServer->getCurrentMailbox());
 		}
 		$uidsToFetch = new Horde_Imap_Client_Ids();
-		if (!(is_object($_uid) || is_array($_uid))) $uid = (array)$_uid;
-		$uidsToFetch->add($uid);
+
+		if (!(is_object($_uid) || is_array($_uid))){
+			$_uid = (array)$_uid;
+		}
+
+		$uidsToFetch->add($_uid);
+
 		try
 		{
 			$_fquery = new Horde_Imap_Client_Fetch_Query();

--- a/api/src/Mail.php
+++ b/api/src/Mail.php
@@ -5647,7 +5647,8 @@ class Mail
 		}
 		$uidsToFetch = new Horde_Imap_Client_Ids();
 
-		if (!(is_object($_uid) || is_array($_uid))){
+		if (!(is_object($_uid) || is_array($_uid)))
+		{
 			$_uid = (array)$_uid;
 		}
 


### PR DESCRIPTION
… if $_uid was an object no structure was returned)