### PR TITLE
Update class.timesheet_datasource.inc.php

### DIFF
--- a/timesheet/inc/class.timesheet_datasource.inc.php
+++ b/timesheet/inc/class.timesheet_datasource.inc.php
@@ -70,6 +70,9 @@ class timesheet_datasource extends datasource
 		{
 			$ds['pe_real_end'] = $data['ts_start'] + 60*$data['ts_duration'];
 			$ds['pe_used_time'] = $data['ts_duration'];
+		} else {
+			$ds['pe_real_end'] = $data['ts_start'];
+			$ds['pe_used_time'] = 0;
 		}
 		if ($this->debug)
 		{


### PR DESCRIPTION
The duration of a time sheet could be 0, which would cause this conditional statement to be false.
This code was responsible for the fact that the sum of the timesheets in the Project Manager app did not match the sum of the timesheets in the Timesheet app.

If someone specified a value for a timesheet linked to a project, e.g. 1 hour, but changed it to 0 after a while.
The attribute "pe_used_time" in the table "egw_pm_elements" didn't get updated because of this code.