### PR TITLE
Fix no automatic login

### DIFF
--- a/login.php
+++ b/login.php
@@ -142,7 +142,7 @@ else
 	$passwd_type = $_POST['passwd_type'];
 
 	// forced password change
-	if($GLOBALS['egw']->session->cd_reason != Api\Session::CD_FORCE_PASSWORD_CHANGE)
+	if($GLOBALS['egw']->session->cd_reason == Api\Session::CD_FORCE_PASSWORD_CHANGE)
 	{
 		// no automatic login
 	}


### PR DESCRIPTION
Hi,

I am trying to do SSO using REMOTE_USER, but it does not work because I am entering in the case of "No automatic login".

I have a reverse proxy (apache) which sends an X-CAS-REMOTE-USER header, which I retrieve from the egroupware nginx.

I added the following configuration on the nginx : 

```
location ^~ /egroupware {
	location ~ ^/egroupware(/(?U).+\.php) {
                ...
		fastcgi_param  REMOTE_USER        $http_x_cas_remote_user;
	}
        ...
}
```

But I am redirected to the login page on which I only need to enter the login field because $ GLOBALS ['egw'] -> session-> cd_reason == NULL.

If I change this condition, SSO is performed correctly. Perhaps this is not the only correction to be made?