### PR TITLE
Fix entrypoint when EGW_SKIP_INSTALL usage

### DIFF
--- a/doc/docker/fpm/entrypoint.sh
+++ b/doc/docker/fpm/entrypoint.sh
@@ -37,7 +37,7 @@ chmod 600 $LOG
 max_retries=10
 export try=0
 # EGW_SKIP_INSTALL=true skips initial installation (no header.inc.php yet)
-until [ -n "$EGW_SKIP_INSTALL" -a ! -f /var/lib/egroupware/header.inc.php ] || \
+until [ -n "$EGW_SKIP_INSTALL" -a -f /var/lib/egroupware/header.inc.php ] || \
 	php /usr/share/egroupware/doc/rpm-build/post_install.php \
 	--start_webserver "" --autostart_webserver "" \
 	--start_db "" --autostart_db "" \


### PR DESCRIPTION
Hi actually,

After the first installation, when i restart docker container with EGW_SKIP_INSTALL=true, entrypoint try to execute `php /usr/share/egroupware/doc/rpm-build/post_install.php` whereas /var/lib/egroupware/header.inc.php exist.

I think the condition is not correct