### PR TITLE
fixed export on windows

### DIFF
--- a/importexport/inc/class.importexport_export_ui.inc.php
+++ b/importexport/inc/class.importexport_export_ui.inc.php
@@ -440,8 +440,14 @@ class importexport_export_ui {
 	 */
 	public function download($_tmpfname = '') {
 		$tmpfname = $_tmpfname ? $_tmpfname : $_GET['_filename'];
-		$tmpfname = $GLOBALS['egw_info']['server']['temp_dir'] .'/'. $tmpfname;
-		if (!is_readable($tmpfname)) die();
+		$tmpfname = $GLOBALS['egw_info']['server']['temp_dir'] . DIRECTORY_SEPARATOR . $tmpfname;
+
+		// windows adds ".tmp" file suffix; so check for that too
+		if (realpath($tmpfname) === FALSE) {
+			$tmpfname = realpath($tmpfname . ".tmp");
+		}
+
+		if ($tmpfname === FALSE || !is_readable($tmpfname)) die();
 
 		$appname = $_GET['_appname'];
 		$nicefname = $_GET['filename'] ? $_GET['filename'] : 'egw_export_'.$appname.'-'.date('Y-m-d');


### PR DESCRIPTION
Temporary files under windows are created with a ".tmp" file suffix. Thus the file is not found/readable when trying to provide the download link. This fix additionally enables the check for a potential ".tmp" file suffix so that the export can be used/tested under windows.