### PR TITLE
Update fw_mobile.js

### DIFF
--- a/pixelegg/js/fw_mobile.js
+++ b/pixelegg/js/fw_mobile.js
@@ -490,7 +490,14 @@ import '@andxor/jquery-ui-touch-punch-fix/jquery.ui.touch-punch.js';
 
 			//Audio effect for toggleMenu
 			var audio = jQuery('#egw_fw_menuAudioTag');
-			if (egw.preference('audio_effect','common') == '1')	audio[0].play();
+			if (egw.preference('audio_effect','common') == '1') {
+				try {
+				  audio[0].play();
+				}
+				catch(err) {
+				  console.log(err);
+				}
+			}
 		},
 
 		/**


### PR DESCRIPTION
Google Chrome returns this error when using EGroupware on mobile:
VM6367 fw_mobile.js:487 Uncaught (in promise) DOMException: play() failed because the user didn't interact with the document first. https://goo.gl/xX8pDD