### PR TITLE
Fix package Name to ssl-cert

### DIFF
--- a/doc/docker/nginx.conf
+++ b/doc/docker/nginx.conf
@@ -21,7 +21,7 @@ server {
 
 	# ssl config (enable following line plus either include or ssl_certificate* line)
 	#listen 443 ssl http2 default_server;
-	#include snippets/snakeoil.conf;	# requires ssl-certs package installed!
+	#include snippets/snakeoil.conf;	# requires ssl-cert package installed!
 	# concatenate private key, certificate and intermediate certs to /etc/ssl/private/certificate.pem
 	#ssl_certificate /etc/ssl/private/certificate.pem;
 	#ssl_certificate_key /etc/ssl/private/certificate.pem;


### PR DESCRIPTION
Fix package Name ssl-certs -> ssl-cert . Tested on Debian 11.