### PR TITLE
FIX : php cmd backup script

### DIFF
--- a/setup/inc/class.setup_cmd_install.inc.php
+++ b/setup/inc/class.setup_cmd_install.inc.php
@@ -78,7 +78,7 @@ class setup_cmd_install extends setup_cmd
 		// use uploaded backup, instead installing from scratch
 		if ($this->backup)
 		{
-			$db_backup = new db_backup();
+			$db_backup = new Api\Db\Backup();
 
 			if (!is_resource($f = $db_backup->fopen_backup($this->backup,true)))
 			{


### PR DESCRIPTION
After launching : 
/usr/share/egroupware/setup/setup-cli.php --install ... inside the container.; getting this error :

An error happened!: Class "db_backup" not found (0)
/usr/share/egroupware/setup/inc/class.setup_cmd_install.inc.php (81)

Solved calling new API\Db\Backup function