### PR TITLE
Fixed: It could happen that calendar Tab remained open after click to…

### DIFF
--- a/calendar/js/et2_widget_timegrid.ts
+++ b/calendar/js/et2_widget_timegrid.ts
@@ -176,9 +176,9 @@ export class et2_calendar_timegrid extends et2_calendar_view implements et2_IDet
 		super.destroy();
 
 		// Delete all old objects
-		this._actionObject.clear();
-		this._actionObject.unregisterActions();
-		this._actionObject.remove();
+		this._actionObject?.clear && this._actionObject.clear();
+		this._actionObject?.unregisterActions && this._actionObject.unregisterActions();
+		this._actionObject?.remove && this._actionObject.remove();
 		this._actionObject = null;
 
 		this.div.off();


### PR DESCRIPTION
… close - "Cannot read properties of undefined (reading 'clear')"

(cherry picked from commit 026591b394066731c2d25c85407984071a7e0769)