### PR TITLE
FIX : adding css max-height on class popupMainDiv to trigger the scollbar when user interface is zoomed.

### DIFF
--- a/pixelegg/less/layout_dialog.less
+++ b/pixelegg/less/layout_dialog.less
@@ -25,6 +25,8 @@ div#popupMainDiv {
     background-color: @gray_0;
     background-repeat: repeat-x;
 	overflow: auto;//If popup is not big enough make sure we can still reach bottom buttons
+	max-height: 98vh;//To trigger a scrollbar when user interface is zoomed (desktop or browser).
+	
 
 }
 


### PR DESCRIPTION
Display problem on the calendar full edit dialog for the new event when user interface is zoomed (desktop or browser) See topic https://help.egroupware.org/t/display-problem-on-the-calendar-full-edit-dialog-for-the-new-events/79255