### PR TITLE
Force autofocus on email field on new addressbook contact windows. 

### DIFF
--- a/addressbook/templates/default/edit.xet
+++ b/addressbook/templates/default/edit.xet
@@ -35,7 +35,7 @@
             </rows>
         </grid>
     </template>
-    <template id="addressbook.edit.general" template="" lang="" group="0" version="1.9.003">
+    <template id="addressbook.edit.general" template="" lang="" group="0" version="1.9.003" onload="document.getElementById(form::name('email')).focus();">
         <grid width="94%">
             <columns>
                 <column width="92"/>


### PR DESCRIPTION
Avoid the focus on "Name" field that is not really editable because its need to be clicked to display the editname popup with prefix, first name, middle name, last name and suffix.
This can solve one problem : if the contact is saved without trigger the onclick function in "Name" field, this field will be cleared.