### PR TITLE
Improved wording of favorite addition, added german and greek translation

### DIFF
--- a/api/lang/egw_de.lang
+++ b/api/lang/egw_de.lang
@@ -594,6 +594,7 @@ floating point	common	de	Gleitkommawert
 folder already exists.	common	de	Ordner existiert bereits!
 fontselect	common	de	Schriftart
 fontsizeselect	common	de	Schriftgröße
+for group	common	de	Für Gruppe
 for more than one contact in a document use the tag pagerepeat!	preferences	de	Verwenden Sie den Tag Seite wiederholen für mehr als einen Kontakt in einem Dokument!
 force	common	de	Erzwungen
 force selectbox	common	de	Auswahlfeld erzwingen
@@ -764,6 +765,7 @@ jordan	common	de	JORDANIEN
 july	common	de	Juli
 jun	common	de	Jun
 june	common	de	Juni
+just for me	common	de	Nur für mich
 justify center	common	de	Ausrichtung mittig
 justify full	common	de	Ausrichtung im Block
 justify left	common	de	Ausrichtung links

--- a/api/lang/egw_el.lang
+++ b/api/lang/egw_el.lang
@@ -47,7 +47,7 @@ add	common	el	Προσθήκη
 add %1 category for	common	el	Προσθήκη κατηγορίας %1 για
 add a new contact	common	el	Προσθέστε μία νέα επαφή
 add category	common	el	Προσθήκη κατηγορίας
-add current	common	el	Προβολή ως αγαπημένο
+add current	common	el	Προσθήκη προβολής στα αγαπημένα
 add shortcut	common	el	Προσθήκη Συντόμευσης
 add sub	common	el	Προσθήκη υπo
 add user to responsibles	groupdav	el	Προσθήκη χρήστη στους υπεύθυνους
@@ -367,6 +367,7 @@ first page	common	el	Αρχική σελίδα
 firstname	common	el	Ονομα
 fixme!	common	el	Διόρθωσέ με!
 folder already exists.	common	el	Ο φάκελος υπάρχει ήδη!
+for group	common	el	Για την ομάδα
 for more than one contact in a document use the tag pagerepeat!	preferences	el	Χρησιμοποιήστε την ετικέτα επανάληψη σελίδας για περισσότερες από μία επαφές σε ένα έγγραφο!
 force selectbox	common	el	Εξανάγκασε Επιλογή κουτιού
 formatted business address	common	el	Διαμορφωμένη επαγγελματική διεύθυνση
@@ -484,6 +485,7 @@ jordan	common	el	ΙΟΡΔΑΝΙΑ
 july	common	el	Ιούλιος
 jun	common	el	Ιούν
 june	common	el	Ιούνιος
+just for me	common	el	Μόνο για μένα
 justify center	common	el	Στοίχιση στο κέντρο
 justify full	common	el	Πλήρης στοίχιση
 justify left	common	el	Στοίχιση αριστερά
@@ -622,7 +624,7 @@ no	common	el	Όχι
 no - cancel	common	el	Όχι-Άκυρο
 no default set	common	el	Δεν έχει οριστεί προεπιλογή
 no entries found, try again ...	common	el	δεν βρέθηκαν καταχωρήσεις, ξαναπροσπαθήστε ...
-no filters	common	el	Δεν υπάρχουν φίλτρα
+no filters	common	el	Αφαίρεση φίλτρων
 no history for this record	common	el	Δεν υπάρχει ιστορικό γι' αυτή την εγγραφή
 no matches found	common	el	Δέν βρέθηκαν όμοια.
 no response from server: your data is probably not saved	common	el	Δεν υπάρχει απάντηση από το διακομιστή: τα δεδομένα σας πιθανόν να ΜΗΝ έχουν αποθηκευτεί.

--- a/api/lang/egw_en.lang
+++ b/api/lang/egw_en.lang
@@ -594,6 +594,7 @@ floating point	common	en	Floating point
 folder already exists.	common	en	Folder already exists!
 fontselect	common	en	Fontselect
 fontsizeselect	common	en	Fontsizeselect
+for group	common	en	For group
 for more than one contact in a document use the tag pagerepeat!	preferences	en	Use the tag page repeat for more than one contact in a document!
 force	common	en	Force
 force selectbox	common	en	Force select box
@@ -764,6 +765,7 @@ jordan	common	en	JORDAN
 july	common	en	July
 jun	common	en	Jun
 june	common	en	June
+just for me	common	en	Just for me
 justify center	common	en	Justify center
 justify full	common	en	Justify full
 justify left	common	en	Justify left

--- a/api/templates/default/add_favorite.xet
+++ b/api/templates/default/add_favorite.xet
@@ -4,7 +4,7 @@
     <template id="nm_print_dialog" template="" lang="" group="0" version="22.1">
         <et2-vbox>
             <et2-textbox  id="name" label="Name" class="et2-label-fixed"/>
-            <et2-select-account  id="group" label="Groups" class="et2-label-fixed" emptyLabel="Just me" accountType="groups"/>
+            <et2-select-account  id="group" label="For group" class="et2-label-fixed" emptyLabel="Just for me" accountType="groups"/>
             <et2-details  summary="Details">
                 <grid id="current_filters">
                     <columns>


### PR DESCRIPTION
Previously, the label used the term “Groups”, which implied that multiple groups could be selected, while the field only supports selecting a single group.

Additionally, changing the wording to “For group” makes the purpose of the select box clearer for users.

Also added German and Greek translations.