### PR TITLE
api/Mail: tokenise search input to align with EGroupware syntax

### DIFF
--- a/api/src/Mail.php
+++ b/api/src/Mail.php
@@ -2301,13 +2301,28 @@ class Mail
 				case 'CC':
 				case 'BCC':
 				case 'SUBJECT':
-					$imapSearchFilter->headerText($criteria, $_criterias['string'], $not=false);
+					$tokenized = self::buildTokenizedSearch($_criterias['string'],
+						function($term, $not) use ($criteria) {
+							$q = new Horde_Imap_Client_Search_Query();
+							$q->charset('UTF-8');
+							$q->headerText($criteria, $term, $not);
+							return $q;
+						});
+					if ($tokenized !== null) $imapSearchFilter->andSearch($tokenized);
 					//$imapSearchFilter->charset('UTF-8');
 					$queryValid = true;
 					break;
 				case 'BODY':
 				case 'TEXT':
-					$imapSearchFilter->text($_criterias['string'],($criteria=='BODY'?true:false), $not=false);
+					$bodyOnly = ($criteria === 'BODY');
+					$tokenized = self::buildTokenizedSearch($_criterias['string'],
+						function($term, $not) use ($bodyOnly) {
+							$q = new Horde_Imap_Client_Search_Query();
+							$q->charset('UTF-8');
+							$q->text($term, $bodyOnly, $not);
+							return $q;
+						});
+					if ($tokenized !== null) $imapSearchFilter->andSearch($tokenized);
 					//$imapSearchFilter->charset('UTF-8');
 					$queryValid = true;
 					break;
@@ -2392,6 +2407,97 @@ class Mail
 		} else {
 			return $imapFilter;
 		}
+	}
+
+	/**
+	 * Tokenize a free-text search string honouring the EGroupware search syntax,
+	 * and combine per-token sub-queries returned by $factory into a single
+	 * Horde_Imap_Client_Search_Query.
+	 *
+	 * Supported syntax (matches Addressbook/Calendar/InfoLog conventions):
+	 *   foo bar       -> contains foo OR contains bar (default)
+	 *   foo or bar    -> contains foo OR contains bar
+	 *   foo and bar   -> contains foo AND contains bar
+	 *   foo +bar      -> contains foo AND contains bar (required)
+	 *   foo -bar      -> contains foo AND NOT contains bar (forbidden)
+	 *   "foo bar"     -> single quoted phrase as one token (preserved verbatim)
+	 *
+	 * Each token is mapped to a Horde sub-query via $factory($term, $not),
+	 * then sub-queries are AND/OR/NOT-combined according to the operator.
+	 * The result is returned as a single composite Horde_Imap_Client_Search_Query
+	 * suitable for passing to andSearch()/orSearch() of an outer query.
+	 *
+	 * @param string $string  Raw user input from the search field
+	 * @param callable $factory  function(string $term, bool $not): Horde_Imap_Client_Search_Query
+	 * @return Horde_Imap_Client_Search_Query|null  null when $string is empty
+	 */
+	protected static function buildTokenizedSearch($string, callable $factory)
+	{
+		$string = trim((string)$string);
+		if ($string === '') return null;
+
+		$tokens = self::parseSearchTokens($string);
+		if (empty($tokens)) return null;
+
+		// Classify tokens into items: ['op'=>'and|or', 'term'=>..., 'not'=>bool]
+		$items = array();
+		$nextOp = 'or';   // EGW default for whitespace-separated tokens
+		foreach ($tokens as $tok)
+		{
+			$lower = strtolower($tok);
+			if ($lower === 'and') { $nextOp = 'and'; continue; }
+			if ($lower === 'or')  { $nextOp = 'or';  continue; }
+
+			$negate = false;
+			$term = $tok;
+			if (strlen($tok) > 1)
+			{
+				if ($tok[0] === '+') { $term = substr($tok, 1); $nextOp = 'and'; }
+				elseif ($tok[0] === '-') { $term = substr($tok, 1); $nextOp = 'and'; $negate = true; }
+			}
+			if ($term === '') continue;
+			$items[] = array('op' => $nextOp, 'term' => $term, 'not' => $negate);
+			$nextOp = 'or';   // reset to default for the next token
+		}
+		if (empty($items)) return null;
+
+		// Single-token shortcut: return the factory output directly
+		if (count($items) === 1)
+		{
+			return $factory($items[0]['term'], $items[0]['not']);
+		}
+
+		// Build composite query left-to-right
+		$combined = $factory($items[0]['term'], $items[0]['not']);
+		for ($i = 1, $n = count($items); $i < $n; $i++)
+		{
+			$sub = $factory($items[$i]['term'], $items[$i]['not']);
+			if ($items[$i]['op'] === 'and') $combined->andSearch($sub);
+			else $combined->orSearch($sub);
+		}
+		return $combined;
+	}
+
+	/**
+	 * Split a search string into tokens, preserving quoted phrases as single tokens.
+	 * Recognised quoting characters: " (double) and ' (single).
+	 *
+	 * @param string $string
+	 * @return array list of token strings (without their surrounding quotes)
+	 */
+	protected static function parseSearchTokens($string)
+	{
+		$tokens = array();
+		if (preg_match_all('/"([^"]*)"|\'([^\']*)\'|(\S+)/u', $string, $m, PREG_SET_ORDER))
+		{
+			foreach ($m as $match)
+			{
+				if (isset($match[1]) && $match[1] !== '') $tokens[] = $match[1];
+				elseif (isset($match[2]) && $match[2] !== '') $tokens[] = $match[2];
+				elseif (isset($match[3]) && $match[3] !== '') $tokens[] = $match[3];
+			}
+		}
+		return $tokens;
 	}
 
 	/**


### PR DESCRIPTION

### Summary

Aligns the Mail module search-box behaviour with the documented EGroupware search syntax used in Addressbook / Calendar / InfoLog. Multi-word queries now match messages whose terms can appear in any order and with arbitrary text between them.

### Problem this solves

Documented in detail in the forum thread (linked below). The Mail search field is the only one in EGroupware that forwards the entire input string to the IMAP server as a single substring match. A query like `invoice overdue` becomes `SEARCH TEXT "invoice overdue"`, so a message body saying *"the invoice from 02/2026 is overdue"* is not matched, even though both words are clearly present.

Even with `fts_flatcurve` enabled on Dovecot, the phrase is matched as a contiguous bigram of tokens, so non-adjacent words remain a hard miss.

### Solution

Two new `protected static` helpers added to `Mail` class:

- `buildTokenizedSearch($string, callable $factory): ?Horde_Imap_Client_Search_Query`
- `parseSearchTokens($string): array`

The relevant case branches (`SUBJECT`, `FROM`, `TO`, `CC`, `BCC`, `BODY`, `TEXT`) in `createIMAPFilter()` now tokenise the input and call the factory for each token, then combine the sub-queries with `Horde_Imap_Client_Search_Query::andSearch()` / `orSearch()` / negation according to the EGroupware-standard operator on each token.

User-facing syntax (matches Addressbook/Calendar/InfoLog):

| Input | Meaning |
|---|---|
| `invoice` | substring "invoice" anywhere |
| `invoice overdue` | "invoice" OR "overdue" (default) |
| `invoice and overdue` | "invoice" AND "overdue" |
| `invoice +overdue` | "invoice" AND "overdue" |
| `invoice -spam` | "invoice" AND NOT "spam" |
| `"invoice overdue"` | literal phrase as a single token |

The resulting IMAP query for `invoice +overdue` with TEXT search type is `(BODY "invoice") (BODY "overdue")` — two index lookups intersected by Dovecot (sub-millisecond with Flatcurve, two linear scans without).

A single-token input produces byte-identical output to the historical generator — no regression on existing user behaviour where they typed one word.

### Files changed

- `api/src/Mail.php` — ~130 lines of effective delta

### Test plan

- [x] Manual UI testing on EGroupware 26.1 (Docker image), Dovecot with `fts_flatcurve`
- [x] Multi-word search with words in arbitrary order — verified match
- [x] Single-word search — verified identical output to before patch
- [x] Negation `-` — verified `AND NOT` semantics
- [x] Quoted phrase `"foo bar"` — verified historical contiguous match preserved
- [ ] Unit tests for `buildTokenizedSearch()` and `parseSearchTokens()` — happy to add as part of review

### Backward compatibility

Fully preserved for single-word inputs. Multi-word inputs change semantics: previously they tried to match a literal contiguous substring (which almost never succeeded), now they apply the documented `A B = A or B` rule. Users who specifically relied on contiguous match (rare) can now wrap the value in double quotes to preserve the old semantics.

### Related

- Forum discussion: https://help.egroupware.org/t/79137
- Companion patch for Sieve filter rules (separate PR): https://github.com/EGroupware/egroupware/pull/<TBD>
- Code gist with the diff: https://gist.github.com/CActor/092c75d6394a0a37fd2b76fa3c2caf34

