### PR TITLE
api/Mail/Sieve: tokenise filter rule values to align with EGroupware …

### DIFF
--- a/api/src/Mail/Sieve/Script.php
+++ b/api/src/Mail/Sieve/Script.php
@@ -88,6 +88,7 @@ class Script
 		$anyofbit = 4;
 		$keepbit = 8;
 		$regexbit = 128;
+		$tokenizedbit = 256;
 
 		if (!isset($this->name)){
 			$this->errstr = 'retrieveRules: no script name specified';
@@ -176,6 +177,7 @@ class Script
 						$rule['anyof']		= ($bits[8] & $anyofbit);
 						$rule['keep']		= ($bits[8] & $keepbit);
 						$rule['regexp']		= ($bits[8] & $regexbit);
+						$rule['tokenized']	= ($bits[8] & $tokenizedbit);
 						$rule['bodytransform'] = ($bits[12]??null);
 						$rule['field_bodytransform'] = ($bits[13]??null);
 						$rule['ctype'] = ($bits[14]??null);
@@ -322,11 +324,24 @@ class Script
 										$newruletext .= 'not ';
 										$rule['from'] = preg_replace("/^\s*!/","",$rule['from']);
 								}
-								$match = ':contains';
-								if (preg_match("/\*|\?/", $rule['from'])) $match = ':matches';
-								if ($rule['regexp']) $match = ':regex';
-								$newruletext .= "address " . $match . " [\"From\"]";
-								$newruletext .= " \"" . addslashes($rule['from']) . "\"";
+								// Tokenized mode: only when the explicit 'tokenized' flag is set
+								// AND regex is off AND value has no wildcards. Existing rules without
+								// the flag keep their historical behaviour verbatim.
+								if (!empty($rule['tokenized']) && !$rule['regexp']
+									&& !preg_match("/\*|\?/", $rule['from']))
+								{
+									$newruletext .= self::buildTokenizedSieveTest($rule['from'],
+										function($term, $not) {
+											$prefix = $not ? 'not ' : '';
+											return $prefix . 'address :contains ["From"] "' . addslashes($term) . '"';
+										});
+								} else {
+									$match = ':contains';
+									if (preg_match("/\*|\?/", $rule['from'])) $match = ':matches';
+									if ($rule['regexp']) $match = ':regex';
+									$newruletext .= "address " . $match . " [\"From\"]";
+									$newruletext .= " \"" . addslashes($rule['from']) . "\"";
+								}
 								$started = 1;
 						}
 						if ($rule['to']) {
@@ -335,11 +350,21 @@ class Script
 										$newruletext .= 'not ';
 										$rule['to'] = preg_replace("/^\s*!/","",$rule['to']);
 								}
-								$match = ':contains';
-								if (preg_match("/\*|\?/", $rule['to'])) $match = ':matches';
-								if ($rule['regexp']) $match = ':regex';
-								$newruletext .= "address " . $match . " [\"To\",\"TO\",\"Cc\",\"CC\"]";
-								$newruletext .= " \"" . addslashes($rule['to']) . "\"";
+								if (!empty($rule['tokenized']) && !$rule['regexp']
+									&& !preg_match("/\*|\?/", $rule['to']))
+								{
+									$newruletext .= self::buildTokenizedSieveTest($rule['to'],
+										function($term, $not) {
+											$prefix = $not ? 'not ' : '';
+											return $prefix . 'address :contains ["To","TO","Cc","CC"] "' . addslashes($term) . '"';
+										});
+								} else {
+									$match = ':contains';
+									if (preg_match("/\*|\?/", $rule['to'])) $match = ':matches';
+									if ($rule['regexp']) $match = ':regex';
+									$newruletext .= "address " . $match . " [\"To\",\"TO\",\"Cc\",\"CC\"]";
+									$newruletext .= " \"" . addslashes($rule['to']) . "\"";
+								}
 								$started = 1;
 						}
 						if ($rule['subject']) {
@@ -348,11 +373,21 @@ class Script
 										$newruletext .= 'not ';
 										$rule['subject'] = preg_replace("/^\s*!/","",$rule['subject']);
 								}
-								$match = ':contains';
-								if (preg_match("/\*|\?/", $rule['subject'])) $match = ':matches';
-								if ($rule['regexp']) $match = ':regex';
-								$newruletext .= "header " . $match . " \"subject\"";
-								$newruletext .= " \"" . addslashes($rule['subject']) . "\"";
+								if (!empty($rule['tokenized']) && !$rule['regexp']
+									&& !preg_match("/\*|\?/", $rule['subject']))
+								{
+									$newruletext .= self::buildTokenizedSieveTest($rule['subject'],
+										function($term, $not) {
+											$prefix = $not ? 'not ' : '';
+											return $prefix . 'header :contains "subject" "' . addslashes($term) . '"';
+										});
+								} else {
+									$match = ':contains';
+									if (preg_match("/\*|\?/", $rule['subject'])) $match = ':matches';
+									if ($rule['regexp']) $match = ':regex';
+									$newruletext .= "header " . $match . " \"subject\"";
+									$newruletext .= " \"" . addslashes($rule['subject']) . "\"";
+								}
 								$started = 1;
 						}
 						if ($rule['field'] && $rule['field_val']) {
@@ -362,31 +397,45 @@ class Script
 										$rule['field_val'] = preg_replace("/^\s*!/","",$rule['field_val']);
 								}
 								$end = '';
-								if (empty($rule['comparator']) || $rule['comparator'] === 'contains')
+								$isContainsMode = empty($rule['comparator']) || $rule['comparator'] === 'contains';
+								if ($isContainsMode && !empty($rule['tokenized']) && !$rule['regexp']
+									&& !preg_match("/\*|\?/", $rule['field_val']))
 								{
-									$match = ':contains';
-									if (preg_match("/\*|\?/", $rule['field_val'])) $match = ':matches';
-									if ($rule['regexp']) $match = ':regex';
+									$headerName = $rule['field'];
+									$newruletext .= self::buildTokenizedSieveTest($rule['field_val'],
+										function($term, $not) use ($headerName) {
+											$prefix = $not ? 'not ' : '';
+											return $prefix . 'header :contains "' . addslashes($headerName) . '" "' . addslashes($term) . '"';
+										});
 								}
 								else
 								{
-									$match = ':value "'.$rule['comparator'].'" :comparator "i;ascii-numeric"';
-									// i;ascii-numeric only accounts for unsigned integers,
-									// negative numbers are always evaluated as positiv infinity,
-									// --> we have to check for the value starting with a minus
-									if (in_array($rule['comparator'], ['gt', 'ge']))
+									if ($isContainsMode)
 									{
-										$newruletext .= 'allof (not header :matches "'.addslashes($rule['field']).'" "-*", ';
-										$end = ')';
+										$match = ':contains';
+										if (preg_match("/\*|\?/", $rule['field_val'])) $match = ':matches';
+										if ($rule['regexp']) $match = ':regex';
 									}
-									elseif (in_array($rule['comparator'], ['lt', 'le']))
+									else
 									{
-										$newruletext .= 'anyof (header :matches "'.addslashes($rule['field']).'" "-*", ';
-										$end = ')';
+										$match = ':value "'.$rule['comparator'].'" :comparator "i;ascii-numeric"';
+										// i;ascii-numeric only accounts for unsigned integers,
+										// negative numbers are always evaluated as positiv infinity,
+										// --> we have to check for the value starting with a minus
+										if (in_array($rule['comparator'], ['gt', 'ge']))
+										{
+											$newruletext .= 'allof (not header :matches "'.addslashes($rule['field']).'" "-*", ';
+											$end = ')';
+										}
+										elseif (in_array($rule['comparator'], ['lt', 'le']))
+										{
+											$newruletext .= 'anyof (header :matches "'.addslashes($rule['field']).'" "-*", ';
+											$end = ')';
+										}
 									}
+									$newruletext .= "header " . $match . " \"" . addslashes($rule['field']) . "\"";
+									$newruletext .= " \"" . addslashes($rule['field_val']) . "\"".$end;
 								}
-								$newruletext .= "header " . $match . " \"" . addslashes($rule['field']) . "\"";
-								$newruletext .= " \"" . addslashes($rule['field_val']) . "\"".$end;
 								$started = 1;
 						}
 						if ($rule['size']) {
@@ -400,11 +449,22 @@ class Script
 							if (!empty($rule['field_bodytransform'])){
 								if ($started) $newruletext .= ", ";
 								$btransform	= " :raw ";
-								$match = ' :contains';
 								if ($rule['bodytransform'])	$btransform = " :text ";
-								if (preg_match("/\*|\?/", $rule['field_bodytransform'])) $match = ':matches';
-								if ($rule['regexp']) $match = ':regex';
-								$newruletext .= "body " . $btransform . $match . " \"" . $rule['field_bodytransform'] . "\"";
+								if (!empty($rule['tokenized']) && !$rule['regexp']
+									&& !preg_match("/\*|\?/", $rule['field_bodytransform']))
+								{
+									$bt = $btransform;
+									$newruletext .= self::buildTokenizedSieveTest($rule['field_bodytransform'],
+										function($term, $not) use ($bt) {
+											$prefix = $not ? 'not ' : '';
+											return $prefix . 'body' . $bt . ':contains "' . addslashes($term) . '"';
+										});
+								} else {
+									$match = ' :contains';
+									if (preg_match("/\*|\?/", $rule['field_bodytransform'])) $match = ':matches';
+									if ($rule['regexp']) $match = ':regex';
+									$newruletext .= "body " . $btransform . $match . " \"" . $rule['field_bodytransform'] . "\"";
+								}
 								$started = 1;
 
 							}
@@ -799,5 +859,101 @@ class Script
 		}
 
 		return true;
+	}
+
+	/**
+	 * Tokenize a free-text filter value honouring the EGroupware search syntax,
+	 * and emit a Sieve test (single or composite allof/anyof/not group).
+	 *
+	 * This helper is only called for rules where the explicit 'tokenized' flag
+	 * is set (third search mode, alongside wildcards and regex). Existing rules
+	 * without the flag use the historical contiguous-substring :contains test.
+	 *
+	 * Supported syntax (matches Addressbook/Calendar/InfoLog conventions, and
+	 * the tokenised IMAP search builder in api/src/Mail.php):
+	 *   foo bar       -> anyof (test(foo), test(bar))   [OR, default for whitespace]
+	 *   foo or bar    -> anyof (test(foo), test(bar))
+	 *   foo and bar   -> allof (test(foo), test(bar))
+	 *   foo +bar      -> allof (test(foo), test(bar))   [required]
+	 *   foo -bar      -> allof (test(foo), not test(bar))   [forbidden]
+	 *   "foo bar"     -> single quoted phrase as one token (preserved verbatim)
+	 *
+	 * @param string $value   raw user input from the filter field
+	 * @param callable $factory  function(string $term, bool $not): string
+	 *                            emits ONE complete Sieve test for $term
+	 * @return string  the Sieve test (single or composite), suitable for joining
+	 *                 with ", " inside an outer allof/anyof. Empty when $value empty.
+	 */
+	static function buildTokenizedSieveTest($value, callable $factory)
+	{
+		$value = trim((string)$value);
+		if ($value === '') return '';
+
+		$tokens = self::parseSieveTokens($value);
+		if (empty($tokens)) return '';
+
+		$items = array();
+		$nextOp = 'anyof';   // EGW default for whitespace-separated tokens
+		foreach ($tokens as $tok)
+		{
+			$lower = strtolower($tok);
+			if ($lower === 'and') { $nextOp = 'allof'; continue; }
+			if ($lower === 'or')  { $nextOp = 'anyof'; continue; }
+
+			$negate = false;
+			$term = $tok;
+			if (strlen($tok) > 1)
+			{
+				if ($tok[0] === '+') { $term = substr($tok, 1); $nextOp = 'allof'; }
+				elseif ($tok[0] === '-') { $term = substr($tok, 1); $nextOp = 'allof'; $negate = true; }
+			}
+			if ($term === '') continue;
+			$items[] = array('op' => $nextOp, 'term' => $term, 'not' => $negate);
+			$nextOp = 'anyof';
+		}
+		if (empty($items)) return '';
+
+		if (count($items) === 1)
+		{
+			return $factory($items[0]['term'], $items[0]['not']);
+		}
+
+		$hasAnd = false; $hasOr = false;
+		foreach ($items as $it) { if ($it['op'] === 'allof') $hasAnd = true; else $hasOr = true; }
+
+		$subtests = array();
+		foreach ($items as $it) { $subtests[] = $factory($it['term'], $it['not']); }
+
+		if ($hasAnd && !$hasOr) return 'allof (' . implode(', ', $subtests) . ')';
+		if ($hasOr && !$hasAnd) return 'anyof (' . implode(', ', $subtests) . ')';
+
+		$combined = $subtests[0];
+		for ($i = 1, $n = count($items); $i < $n; $i++)
+		{
+			$op = $items[$i]['op'];
+			$combined = $op . ' (' . $combined . ', ' . $subtests[$i] . ')';
+		}
+		return $combined;
+	}
+
+	/**
+	 * Split a filter value into tokens, preserving quoted phrases as single tokens.
+	 *
+	 * @param string $string
+	 * @return array list of token strings (without their surrounding quotes)
+	 */
+	static function parseSieveTokens($string)
+	{
+		$tokens = array();
+		if (preg_match_all('/"([^"]*)"|\'([^\']*)\'|(\S+)/u', $string, $m, PREG_SET_ORDER))
+		{
+			foreach ($m as $match)
+			{
+				if (isset($match[1]) && $match[1] !== '') $tokens[] = $match[1];
+				elseif (isset($match[2]) && $match[2] !== '') $tokens[] = $match[2];
+				elseif (isset($match[3]) && $match[3] !== '') $tokens[] = $match[3];
+			}
+		}
+		return $tokens;
 	}
 }

--- a/mail/inc/class.mail_sieve.inc.php
+++ b/mail/inc/class.mail_sieve.inc.php
@@ -270,6 +270,7 @@ class mail_sieve
 						break;
 				}
 				$content['anyof'] = $rules['anyof'] != 0?1:0;
+				$content['tokenized'] = !empty($rules['tokenized']) ? 1 : 0;
 			}
 			else // Adding new rule
 			{
@@ -277,6 +278,8 @@ class mail_sieve
 				$newRulePriority = count($this->rules)*2+1;
 				$newRules ['priority'] = $newRulePriority;
 				$newRules ['status'] = 'ENABLED';
+				// Default 'tokenized' to the user's last choice (persistent preference)
+				$newRules ['tokenized'] = (int)($GLOBALS['egw_info']['user']['preferences']['mail']['sieve_last_tokenized'] ?? 0);
 				$readonlys = array(
 					'button[delete]' => 'true',
 					);
@@ -333,6 +336,13 @@ class mail_sieve
 						if( $newRule['anyof'] )    { $newRule['flg'] += 4; }
 						if( $newRule['keep'] )     { $newRule['flg'] += 8; }
 						if( $newRule['regexp'] )   { $newRule['flg'] += 128; }
+						if( !empty($newRule['tokenized']) ) { $newRule['flg'] += 256; }
+
+						// Persist the user's last 'tokenized' choice so the next new rule
+						// inherits it as default (per-user preference, survives logout).
+						$GLOBALS['egw']->preferences->add('mail', 'sieve_last_tokenized',
+							!empty($newRule['tokenized']) ? 1 : 0, 'user');
+						$GLOBALS['egw']->preferences->save_repository(true, 'user');
 
 						if (!empty($newRule['field']) && $newRule['comparator'] !== 'contains' && !preg_match('/^[0-9]+/', $newRule['field_val']))
 						{

--- a/mail/templates/default/sieve.edit.xet
+++ b/mail/templates/default/sieve.edit.xet
@@ -139,6 +139,9 @@
 				<row>
 					<et2-checkbox  label="Use regular expressions (see wikipedia for information on POSIX regular expressions)" id="regexp"></et2-checkbox>
 				</row>
+				<row>
+					<et2-checkbox  label="Use tokenised search syntax (+word required, -word forbidden, &quot;...&quot; literal phrase; same as the EGroupware search box)" id="tokenized"></et2-checkbox>
+				</row>
 				<row class="dialogFooterToolbar">
 					<et2-hbox  width="100%">
 						<et2-button  statustext="Saves this rule" label="Save" id="button[save]"></et2-button>


### PR DESCRIPTION
### Summary

Extends the IMAP-search tokenisation introduced in #240 to the **Mail filter rules** (Sieve scripts generated by EGroupware), gated behind a **per-rule opt-in checkbox**. Existing rules are unaffected at deploy time — zero regression.

Depends on / pairs with #240.

Discussion: https://help.egroupware.org/t/79137

### Why a second patch

#240 makes the Mail search box accept the EGroupware-standard `+token`, `-token`, `and`, `or`, `"..."` syntax (same as Addressbook / Calendar / InfoLog). But the **same user-facing limitation also applies to Mail filter rules**: a filter "Subject contains *invoice overdue*" still produces a Sieve `header :contains "subject" "invoice overdue"` test, which only matches the literal contiguous substring.

From the end-user point of view it is unintuitive that the search box and the filter rules of the same module follow two different syntaxes. This PR closes the loop so users get one mental model across the whole Mail module.

### Design — opt-in per rule

Following the request in https://help.egroupware.org/t/79137 to *"not change existing rules silently"*, the new behaviour is fully gated.

**New per-rule checkbox** in `mail/templates/default/sieve.edit.xet`:

> **☐ Use tokenised search syntax** *(+word required, -word forbidden, "..." literal phrase; same as the EGroupware search box)*

**Persistence**: stored as the next free bit `256` in the existing `flg` integer column of the rule — no schema migration, no new column, no DB touch.

**Generator gating** in `api/src/Mail/Sieve/Script.php`: the tokenised branch only fires when `($rule['flg'] & 256)` AND `!$rule['regexp']` AND the value has no `*`/`?` wildcards. All other modes (regex, wildcards, plain unchecked) are emitted exactly as before.

**Small UX touch** in `mail/inc/class.mail_sieve.inc.php`: the last state of the checkbox is remembered as a per-user preference (`mail/sieve_last_tokenized`) and used as the default for the next new rule that user creates. Existing rules are unaffected by the preference — only the default for new ones.

### User-facing syntax (only when the checkbox is ticked)

| Input in any filter value field | Meaning |
|---|---|
| `invoice` | substring "invoice" anywhere |
| `invoice overdue` | "invoice" OR "overdue" (default for whitespace) |
| `invoice and overdue` | "invoice" AND "overdue" |
| `invoice +overdue` | "invoice" AND "overdue" |
| `invoice -spam` | "invoice" AND NOT "spam" |
| `"invoice overdue"` | literal phrase as one token (= legacy behaviour) |

Affected condition rows (in plain `:contains` mode only): From, To, Subject, custom header, body (`:text` / `:raw`). Numeric comparators, size check, attachment-type filter are untouched.

### Generated Sieve

For a rule with the checkbox ticked, `Subject contains invoice +overdue`:

```sieve
if allof (
    allof (
        header :contains "subject" "invoice",
        header :contains "subject" "overdue"
    )
) {
    fileinto "Reminders";
}
```

For an unticked rule (default), output is **byte-identical to the unpatched generator** — no regression risk for existing filters.

### Files changed (3)

1. **`api/src/Mail/Sieve/Script.php`** — adds two `static` helpers (`buildTokenizedSieveTest`, `parseSieveTokens`), the `$tokenizedbit = 256` constant, the tokenised branch in 5 `case` blocks (FROM / TO / SUBJECT / custom header / body).
2. **`mail/templates/default/sieve.edit.xet`** — adds the new `<et2-checkbox id="tokenized">` after the existing `regexp` checkbox.
3. **`mail/inc/class.mail_sieve.inc.php`** — load/save of `flg & 256`, plus the per-user `sieve_last_tokenized` preference.

~204 lines effective delta, no new dependencies, no schema migration.

### Backward compatibility — zero deploy-time regression

Because the patch is gated on `flg & 256`, **no existing rule changes behaviour at deploy time**. Rules saved before the patch have `flg & 256 == 0`, so the generator emits the historical contiguous `:contains` Sieve, byte-identical to pre-patch. The editor renders existing rules with the new checkbox unchecked, which is the correct default for legacy rules.

The first time a user explicitly opens an existing rule, ticks the checkbox, and saves, that single rule is regenerated under the patched generator with `flg += 256`. From that moment on the rule uses tokenised matching. No data migration, no admin action required.

For instances that prefer to bulk-normalise the stored Sieve scripts at deploy time anyway (e.g. to validate the patched parser end-to-end across all users), an optional CLI helper `resave-sieve-rules.php` is provided in the companion gist below. It iterates all active users and round-trips their rules through `retrieveRules() → setRules()`. Pure bookkeeping, no semantic effect.

### Test plan

- [x] Manual UI testing on EGroupware 26.1 (Docker image), Dovecot with `fts_flatcurve` enabled. Patched files bind-mounted source-side to survive Watchtower image updates.
- [x] 34 functional test cases via SMTP from a separate Gmail account:
  - 8 tokenised positives (checkbox ticked: AND / OR / `+`token / `-`token / quoted phrase / case-insensitive / cross-position / substring-of-larger-word) — all matched as expected
  - 4 tokenised negatives (missing required token, forbidden token present, spaced-out non-substring) — correctly stayed in INBOX
  - 22 legacy rules (checkbox unticked) — routed identically to pre-patch behaviour for every message, zero regression
- [x] Re-save migration script (`resave-sieve-rules.php`) tested live on 48 existing user rules; produces no diff vs. baseline for legacy-mode rules.
- [ ] Unit tests for `buildTokenizedSieveTest()` and `parseSieveTokens()` — happy to add as part of review.

### Code-sharing note (for review-time discussion)

The tokeniser in this PR (`buildTokenizedSieveTest` / `parseSieveTokens`) is structurally identical to the one in #240 (`buildTokenizedSearch` / `parseSearchTokens`). I deliberately left both as their own static methods on each class to keep this PR minimal-impact. If you prefer a shared `EGroupware\Api\Mail\SearchTokeniserTrait` factored out before either PR is merged, I am happy to do the refactor on the search PR first, then this one will reuse the trait. Just let me know on either thread.

### Related

- Companion PR (prerequisite, IMAP search side): #240
- Forum discussion: https://help.egroupware.org/t/79137
- Code gist with full diff + migration helper: https://gist.github.com/CActor/82621b8df78662e6117cb3beeedb94e0

This PR is marked as **Draft** because #240 is its functional prerequisite (both should be reviewed together; this one converted to ready-for-review once #240 is mergeable).
