### PR TITLE
Calendar: REST API tests adapted from CalDAV tests

### DIFF
--- a/api/tests/RestBase.php
+++ b/api/tests/RestBase.php
@@ -1,0 +1,283 @@
+<?php
+/**
+ * REST API tests base class
+ *
+ * Performs REST (JSON / JsCalendar / JsContact) requests against the same
+ * EGroupware groupdav.php endpoint as the CalDAV/CardDAV tests, but using the
+ * REST API instead of WebDAV methods.
+ *
+ * It extends {@see CalDAVTest} to reuse all the heavy lifting (user/ACL setup,
+ * authentication, cleanup of created events and the HTTP status assertions) and
+ * only adds JSON-specific request- and assertion-helpers.
+ *
+ * Key differences between the REST API and CalDAV (see doc/REST-CalDAV-CardDAV/):
+ * - resources are addressed by their numeric id, NOT by "<uid>.ics": for JSON
+ *   requests calendar_groupdav sets $path_attr='id' and $path_extension=''
+ * - new resources are created with a POST to the collection; the "Location"
+ *   header and "ETag" of the response contain the new id
+ * - requests carry a "Content-Type: application/json" (POST/PUT/PATCH) and/or
+ *   "Accept: application/json" (GET/DELETE) header, which is how the server
+ *   tells REST and CalDAV requests apart (see Api\CalDAV::isJSON())
+ * - a DELETE REST request MUST send an "Accept: application/json" header,
+ *   otherwise the CalDAV server returns 404, as the url does not end in .ics
+ *
+ * @link https://www.egroupware.org
+ * @author Ralf Becker <rb@egroupware.org>
+ * @package api
+ * @subpackage caldav
+ * @copyright (c) 2020 by Ralf Becker <rb@egroupware.org>
+ * @license http://opensource.org/licenses/gpl-license.php GPL - GNU General Public License
+ */
+
+namespace EGroupware\Api;
+
+require_once __DIR__.'/CalDAVTest.php';
+
+use GuzzleHttp\RequestOptions;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Abstract base class for REST API tests against the EGroupware groupdav.php endpoint.
+ *
+ * @package EGroupware\Api
+ */
+abstract class RestBase extends CalDAVTest
+{
+	/**
+	 * Content-Type / Accept used to select the REST (JSON) API
+	 */
+	const JSON_CONTENT_TYPE = 'application/json';
+
+	/**
+	 * URL of a user's calendar collection, e.g. "/<user>/calendar/"
+	 *
+	 * @param string $user account_lid of the calendar owner
+	 * @return string
+	 */
+	protected function calendarCollection(string $user) : string
+	{
+		return '/'.$user.'/calendar/';
+	}
+
+	/**
+	 * URL of a single event, addressed by its numeric id (REST does NOT use a .ics suffix!)
+	 *
+	 * @param string $user account_lid of the calendar owner / view
+	 * @param int|string $id numeric cal_id of the event
+	 * @return string
+	 */
+	protected function eventResource(string $user, $id) : string
+	{
+		return '/'.$user.'/calendar/'.$id;
+	}
+
+	/**
+	 * Default JSON request headers, $extra is merged in last (and can overwrite them)
+	 *
+	 * @param array $extra additional headers
+	 * @return array
+	 */
+	protected function jsonHeaders(array $extra=[]) : array
+	{
+		return array_merge([
+			'Content-Type' => self::JSON_CONTENT_TYPE,
+			'Accept'       => self::JSON_CONTENT_TYPE,
+		], $extra);
+	}
+
+	/**
+	 * Encode a JsEvent / JsContact array as a JSON request body
+	 *
+	 * @param array $data
+	 * @return string
+	 */
+	protected function jsonBody(array $data) : string
+	{
+		return json_encode($data, JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE);
+	}
+
+	/**
+	 * Decode a JSON response body into an array
+	 *
+	 * @param ResponseInterface $response
+	 * @return array decoded body or [] if not (valid) JSON
+	 */
+	protected function jsonDecode(ResponseInterface $response) : array
+	{
+		$data = json_decode((string)$response->getBody(), true);
+		return is_array($data) ? $data : [];
+	}
+
+	/**
+	 * POST a JsEvent to a user's calendar collection to create a new event.
+	 *
+	 * By default "Prefer: return=representation" is requested, so the response
+	 * body contains the fully expanded JsEvent.
+	 *
+	 * @param array $event JsEvent
+	 * @param ?string $user account_lid of the calendar owner, default organizer/EGW_USER
+	 * @param array $headers additional headers
+	 * @return ResponseInterface 201 Created on success; Location & ETag contain the new id
+	 */
+	protected function postEvent(array $event, ?string $user=null, array $headers=[]) : ResponseInterface
+	{
+		$user = $user ?: $this->organizerLid();
+		return $this->getClient($user)->post($this->url($this->calendarCollection($user)), [
+			RequestOptions::HEADERS => $this->jsonHeaders(array_merge([
+				'Prefer' => 'return=representation',
+			], $headers)),
+			RequestOptions::BODY => $this->jsonBody($event),
+		]);
+	}
+
+	/**
+	 * PUT a full JsEvent to an existing resource (addressed by numeric id).
+	 *
+	 * Note the REST PUT requires all attributes to be specified.
+	 *
+	 * @param int|string $id numeric cal_id
+	 * @param array $event JsEvent
+	 * @param ?string $user account_lid of the calendar owner, default organizer/EGW_USER
+	 * @param array $headers additional headers, e.g. ['If-Match' => $etag]
+	 * @return ResponseInterface
+	 */
+	protected function putEventJson($id, array $event, ?string $user=null, array $headers=[]) : ResponseInterface
+	{
+		$user = $user ?: $this->organizerLid();
+		return $this->getClient($user)->put($this->url($this->eventResource($user, $id)), [
+			RequestOptions::HEADERS => $this->jsonHeaders($headers),
+			RequestOptions::BODY => $this->jsonBody($event),
+		]);
+	}
+
+	/**
+	 * PATCH a resource with a partial JsEvent (RFC 8984 PatchObject).
+	 *
+	 * @param int|string $id numeric cal_id
+	 * @param array $patch partial JsEvent / PatchObject
+	 * @param ?string $user account_lid of the calendar owner, default organizer/EGW_USER
+	 * @param array $headers additional headers
+	 * @return ResponseInterface
+	 */
+	protected function patchEventJson($id, array $patch, ?string $user=null, array $headers=[]) : ResponseInterface
+	{
+		$user = $user ?: $this->organizerLid();
+		return $this->getClient($user)->patch($this->url($this->eventResource($user, $id)), [
+			RequestOptions::HEADERS => $this->jsonHeaders($headers),
+			RequestOptions::BODY => $this->jsonBody($patch),
+		]);
+	}
+
+	/**
+	 * GET a single resource and return the raw Guzzle response (Accept: application/json).
+	 *
+	 * @param int|string $id numeric cal_id
+	 * @param ?string $user account_lid of the calendar owner, default organizer/EGW_USER
+	 * @param array $headers additional headers
+	 * @return ResponseInterface
+	 */
+	protected function getEventResponse($id, ?string $user=null, array $headers=[]) : ResponseInterface
+	{
+		$user = $user ?: $this->organizerLid();
+		return $this->getClient($user)->get($this->url($this->eventResource($user, $id)), [
+			RequestOptions::HEADERS => $this->jsonHeaders($headers),
+		]);
+	}
+
+	/**
+	 * GET a single resource and return the decoded JsEvent (asserts HTTP 200).
+	 *
+	 * @param int|string $id numeric cal_id
+	 * @param ?string $user account_lid of the calendar owner, default organizer/EGW_USER
+	 * @return array decoded JsEvent
+	 */
+	protected function getEventJson($id, ?string $user=null) : array
+	{
+		$response = $this->getEventResponse($id, $user);
+		$this->assertHttpStatus(200, $response);
+		return $this->jsonDecode($response);
+	}
+
+	/**
+	 * DELETE a single resource.
+	 *
+	 * The "Accept: application/json" header is REQUIRED for REST DELETE requests,
+	 * otherwise the CalDAV server returns 404 (url does not end in .ics).
+	 *
+	 * @param int|string $id numeric cal_id
+	 * @param ?string $user account_lid of the calendar owner / view, default organizer/EGW_USER
+	 * @param array $headers additional headers
+	 * @return ResponseInterface
+	 */
+	protected function deleteEvent($id, ?string $user=null, array $headers=[]) : ResponseInterface
+	{
+		$user = $user ?: $this->organizerLid();
+		return $this->getClient($user)->delete($this->url($this->eventResource($user, $id)), [
+			RequestOptions::HEADERS => $this->jsonHeaders($headers),
+		]);
+	}
+
+	/**
+	 * Extract the numeric event id of a freshly created resource from the response
+	 * (preferring the Location header, falling back to the ETag) and track it for cleanup.
+	 *
+	 * @param ResponseInterface $response create (POST/PUT) response
+	 * @return int|string new id, or '' if none could be determined
+	 */
+	protected function idFromResponse(ResponseInterface $response)
+	{
+		// Location: .../groupdav.php/<user>/calendar/<id>
+		$location = $response->getHeader('Location')[0] ?? '';
+		if ($location !== '' && preg_match('#/calendar/([^/?\#]+)$#', $location, $matches))
+		{
+			$id = $matches[1];
+		}
+		else
+		{
+			// ETag: "<cal_id>:<recurrence>:<modified>"
+			$etag = $response->getHeader('ETag')[0] ?? '';
+			$parts = explode(':', trim($etag, '[]"'));
+			$id = $parts[0] ?? '';
+		}
+		if (is_numeric($id))
+		{
+			self::trackCalId((int)$id);
+		}
+		return $id;
+	}
+
+	/**
+	 * Find a participant in a JsEvent by its (case-insensitive) email address.
+	 *
+	 * @param array $event JsEvent
+	 * @param string $email
+	 * @return array|null participant object or null if not found
+	 */
+	protected function findParticipantByEmail(array $event, string $email) : ?array
+	{
+		foreach($event['participants'] ?? [] as $participant)
+		{
+			if (isset($participant['email']) && strtolower($participant['email']) === strtolower($email))
+			{
+				return $participant;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Assert a participant identified by its email has an expected participationStatus.
+	 *
+	 * @param array $event JsEvent (e.g. from getEventJson())
+	 * @param string $email participant email
+	 * @param string $expected_status e.g. "accepted", "declined", "needs-action", "tentative"
+	 * @param string $message additional message prefix
+	 */
+	protected function assertParticipationStatus(array $event, string $email, string $expected_status, string $message='') : void
+	{
+		$participant = $this->findParticipantByEmail($event, $email);
+		$this->assertNotNull($participant, (!empty($message) ? $message.': ' : '')."Participant $email not found in event");
+		$this->assertEquals($expected_status, $participant['participationStatus'] ?? null,
+			(!empty($message) ? $message.': ' : '')."Unexpected participationStatus for $email");
+	}
+}

--- a/calendar/tests/REST/CreateReadDeleteTest.php
+++ b/calendar/tests/REST/CreateReadDeleteTest.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * REST API tests: create, read and delete an event
+ *
+ * REST (JSON / JsCalendar) equivalent of
+ * calendar/tests/CalDAV/CreateReadDeleteTest.php.
+ *
+ * Instead of CalDAV/WebDAV requests (PUT/GET/DELETE of "<uid>.ics" with
+ * text/calendar bodies and PROPFIND for principal discovery) it uses the REST
+ * API: a POST of a JsEvent to the collection to create, GET/DELETE of the
+ * numeric resource id with "Accept: application/json", and a GET on the
+ * collection for discovery.
+ *
+ * @link https://www.egroupware.org
+ * @author Ralf Becker <rb@egroupware.org>
+ * @package calendar
+ * @subpackage tests
+ * @copyright (c) 2020 by Ralf Becker <rb@egroupware.org>
+ * @license http://opensource.org/licenses/gpl-license.php GPL - GNU General Public License
+ */
+
+namespace EGroupware\calendar\REST;
+
+require_once __DIR__.'/../../../api/tests/RestBase.php';
+
+use EGroupware\Api\RestBase;
+use GuzzleHttp\RequestOptions;
+use PHPUnit\Framework\Attributes\Depends;
+
+class CreateReadDeleteTest extends RestBase
+{
+	protected const EVENT_UID = 'rest-event-create-read-delete';
+	protected const EVENT_FIXTURE = __DIR__.'/fixtures/create-read-delete-event.json.tpl';
+
+	/**
+	 * UID of the event, generated once per test class
+	 */
+	protected static $event_uid;
+
+	/**
+	 * Numeric cal_id of the created event, shared between the dependent tests
+	 *
+	 * @var int|string
+	 */
+	protected static $cal_id;
+
+	public static function setUpBeforeClass() : void
+	{
+		parent::setUpBeforeClass();
+		self::$event_uid = self::EVENT_UID.'-'.gmdate('YmdHis').'-'.bin2hex(random_bytes(2));
+		self::trackUid(self::$event_uid);
+	}
+
+	protected function user() : string
+	{
+		return $GLOBALS['EGW_USER'];
+	}
+
+	/**
+	 * Build the JsEvent payload to create, from the fixture template.
+	 *
+	 * @return array decoded JsEvent
+	 */
+	protected function eventPayload() : array
+	{
+		$template = file_get_contents(self::EVENT_FIXTURE);
+		$this->assertNotFalse($template, 'Unable to load event fixture');
+		$event = json_decode(strtr($template, ['{{UID}}' => self::$event_uid]), true);
+		$this->assertIsArray($event, 'Event fixture is not valid JSON');
+		return $event;
+	}
+
+	/**
+	 * Verify the REST endpoint rejects anonymous access.
+	 *
+	 * Pass criteria:
+	 * - GET on the calendar collection without auth returns HTTP 401.
+	 */
+	public function testNoAuth()
+	{
+		$response = $this->getClient([])->get($this->url($this->calendarCollection($this->user())), [
+			RequestOptions::HEADERS => $this->jsonHeaders(),
+		]);
+
+		$this->assertHttpStatus(401, $response);
+	}
+
+	/**
+	 * Verify authenticated collection discovery works (REST equivalent of PROPFIND).
+	 *
+	 * Pass criteria:
+	 * - GET on the authenticated user's calendar collection with
+	 *   "Accept: application/json" returns HTTP 200 and a JSON body.
+	 */
+	public function testAuth()
+	{
+		$response = $this->getEventResponse('', $this->user());
+
+		$this->assertHttpStatus(200, $response);
+		$this->assertIsArray($this->jsonDecode($response), 'Collection response is not valid JSON');
+	}
+
+	/**
+	 * Create event from the JsEvent fixture payload.
+	 *
+	 * Setup:
+	 * - Load fixture template and inject the test UID.
+	 *
+	 * Pass criteria:
+	 * - POST returns HTTP 200 or 201.
+	 * - Response carries a numeric id (Location header / ETag).
+	 */
+	public function testCreate()
+	{
+		$response = $this->postEvent($this->eventPayload(), $this->user());
+
+		$this->assertHttpStatus([200, 201], $response);
+
+		self::$cal_id = $this->idFromResponse($response);
+		$this->assertNotEmpty(self::$cal_id, 'No id returned for created event');
+		$this->assertTrue(is_numeric(self::$cal_id), 'Returned id is not numeric: '.self::$cal_id);
+	}
+
+	/**
+	 * Read created event and verify the JsEvent payload parity.
+	 *
+	 * Pass criteria:
+	 * - GET returns HTTP 200.
+	 * - Returned JsEvent matches the fixture payload semantics.
+	 */
+	#[Depends('testCreate')]
+	public function testRead()
+	{
+		$event = $this->getEventJson(self::$cal_id, $this->user());
+
+		$this->assertEquals('Tonight', $event['title'] ?? null, 'Unexpected title');
+		$this->assertEquals('2030-01-01T20:00:00', $event['start'] ?? null, 'Unexpected start');
+		$this->assertEquals('Europe/Berlin', $event['timeZone'] ?? null, 'Unexpected timeZone');
+		$this->assertEquals('PT1H', $event['duration'] ?? null, 'Unexpected duration');
+		$this->assertEquals('Somewhere', $event['locations']['1']['name'] ?? null, 'Unexpected location');
+	}
+
+	/**
+	 * Delete created event resource.
+	 *
+	 * Pass criteria:
+	 * - DELETE returns HTTP 204.
+	 */
+	#[Depends('testCreate')]
+	public function testDelete()
+	{
+		$response = $this->deleteEvent(self::$cal_id, $this->user());
+
+		$this->assertHttpStatus(204, $response);
+	}
+
+	/**
+	 * Verify deleted event is no longer readable.
+	 *
+	 * Pass criteria:
+	 * - GET returns HTTP 404 after delete.
+	 */
+	#[Depends('testDelete')]
+	public function testReadDeleted()
+	{
+		$response = $this->getEventResponse(self::$cal_id, $this->user());
+
+		$this->assertHttpStatus(404, $response);
+	}
+
+	/**
+	 * Delete of a non-existing event must return not-found.
+	 *
+	 * Setup:
+	 * - Build a unique, never-created resource name in the authenticated user's
+	 *   calendar collection.
+	 *
+	 * Pass criteria:
+	 * - DELETE returns HTTP 404.
+	 */
+	public function testDeleteMissing()
+	{
+		$missing = $this->makeUid('rest-delete-missing');
+		$response = $this->deleteEvent($missing, $this->user());
+
+		$this->assertHttpStatus(404, $response);
+	}
+}

--- a/calendar/tests/REST/PutPreconditionTest.php
+++ b/calendar/tests/REST/PutPreconditionTest.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * REST API PUT precondition tests (ETag / Schedule-Tag).
+ *
+ * REST (JSON / JsCalendar) equivalent of
+ * calendar/tests/CalDAV/PutPreconditionTest.php.
+ *
+ * The event is created with a POST of a JsEvent and afterwards updated with a
+ * PUT to its numeric resource id, carrying the same "If-Match" /
+ * "If-Schedule-Tag-Match" precondition headers as the CalDAV variant. The
+ * precondition handling lives in the shared CalDAV request handler, so it
+ * applies to REST PUT requests identically.
+ *
+ * @package calendar
+ * @subpackage tests
+ * @license http://opensource.org/licenses/gpl-license.php GPL - GNU General Public License
+ */
+
+namespace EGroupware\calendar\REST;
+
+require_once __DIR__.'/../../../api/tests/RestBase.php';
+
+use EGroupware\Api\RestBase;
+
+class PutPreconditionTest extends RestBase
+{
+	protected const EVENT_FIXTURE = __DIR__.'/fixtures/create-read-delete-event.json.tpl';
+
+	protected function ownerUser() : string
+	{
+		$this->assertNotEmpty($GLOBALS['EGW_USER'], 'EGW_USER must be configured for REST tests');
+		return $GLOBALS['EGW_USER'];
+	}
+
+	/**
+	 * Build a JsEvent payload from the fixture with a given UID and title.
+	 */
+	protected function eventPayload(string $uid, string $title) : array
+	{
+		$template = file_get_contents(self::EVENT_FIXTURE);
+		$this->assertNotFalse($template, 'Unable to load event fixture');
+		$event = json_decode(strtr($template, ['{{UID}}' => $uid]), true);
+		$this->assertIsArray($event, 'Event fixture is not valid JSON');
+		$event['title'] = $title;
+		return $event;
+	}
+
+	/**
+	 * Create an event via POST and return its numeric id.
+	 */
+	protected function createEvent(string $uid, string $title='Precondition Base')
+	{
+		$response = $this->postEvent($this->eventPayload($uid, $title), $this->ownerUser());
+		$this->assertHttpStatus([200, 201], $response);
+		$id = $this->idFromResponse($response);
+		$this->assertNotEmpty($id, 'No id returned for created event');
+		return $id;
+	}
+
+	/**
+	 * GET the current title of an event.
+	 */
+	protected function currentTitle($id) : ?string
+	{
+		return $this->getEventJson($id, $this->ownerUser())['title'] ?? null;
+	}
+
+	/**
+	 * Stale ETag precondition must block overwrite.
+	 *
+	 * Setup:
+	 * - Create event.
+	 * - Attempt PUT update with an intentionally stale "If-Match".
+	 *
+	 * Pass criteria:
+	 * - PUT returns HTTP 412.
+	 * - Event content remains unchanged.
+	 */
+	public function testPutWithStaleIfMatchReturns412()
+	{
+		$uid = $this->makeUid('calendar-rest-ifmatch-stale');
+		$id = $this->createEvent($uid, 'IfMatch Base');
+
+		$update = $this->putEventJson($id, $this->eventPayload($uid, 'IfMatch Updated'), $this->ownerUser(), [
+			'If-Match' => '"stale-etag-value"',
+		]);
+		$this->assertHttpStatus(412, $update);
+
+		$this->assertEquals('IfMatch Base', $this->currentTitle($id), 'Event must not have been updated');
+	}
+
+	/**
+	 * Matching ETag precondition allows update.
+	 *
+	 * Setup:
+	 * - Create event and fetch its current ETag from a GET.
+	 * - PUT updated payload with the exact "If-Match" value.
+	 *
+	 * Pass criteria:
+	 * - PUT returns success (200/204).
+	 * - Subsequent GET contains the updated title.
+	 */
+	public function testPutWithMatchingIfMatchSucceeds()
+	{
+		$uid = $this->makeUid('calendar-rest-ifmatch-ok');
+		$id = $this->createEvent($uid, 'IfMatch Success Base');
+
+		$current = $this->getEventResponse($id, $this->ownerUser());
+		$this->assertHttpStatus(200, $current);
+		$etag = $current->getHeader('ETag')[0] ?? '';
+		$this->assertNotEmpty($etag, 'Expected ETag header on GET response');
+
+		$update = $this->putEventJson($id, $this->eventPayload($uid, 'IfMatch Success Updated'), $this->ownerUser(), [
+			'If-Match' => $etag,
+		]);
+		$this->assertHttpStatus([200, 204], $update);
+
+		$this->assertEquals('IfMatch Success Updated', $this->currentTitle($id), 'Event should have been updated');
+	}
+
+	/**
+	 * Stale schedule-tag precondition must return 412.
+	 *
+	 * Setup:
+	 * - Create event.
+	 * - PUT updated payload with an intentionally stale "If-Schedule-Tag-Match".
+	 *
+	 * Pass criteria:
+	 * - PUT returns HTTP 412.
+	 * - Event content remains unchanged.
+	 */
+	public function testPutWithStaleScheduleTagReturns412()
+	{
+		$uid = $this->makeUid('calendar-rest-scheduletag-stale');
+		$id = $this->createEvent($uid, 'ScheduleTag Base');
+
+		$update = $this->putEventJson($id, $this->eventPayload($uid, 'ScheduleTag Updated'), $this->ownerUser(), [
+			'If-Schedule-Tag-Match' => '"stale-schedule-tag"',
+		]);
+		$this->assertHttpStatus(412, $update);
+
+		$this->assertEquals('ScheduleTag Base', $this->currentTitle($id), 'Event must not have been updated');
+	}
+
+	/**
+	 * Event owner: If-Match takes precedence when both preconditions are present.
+	 *
+	 * Setup:
+	 * - Create event and fetch its current ETag.
+	 * - PUT update with a valid "If-Match" and a stale "If-Schedule-Tag-Match".
+	 *
+	 * Pass criteria:
+	 * - Update succeeds (owner path ignores stale schedule-tag when both are sent).
+	 * - Updated title is returned by a later GET.
+	 */
+	public function testOwnerIfMatchTakesPrecedenceOverScheduleTag()
+	{
+		$uid = $this->makeUid('calendar-rest-owner-header-precedence');
+		$id = $this->createEvent($uid, 'Header Precedence Base');
+
+		$current = $this->getEventResponse($id, $this->ownerUser());
+		$this->assertHttpStatus(200, $current);
+		$etag = $current->getHeader('ETag')[0] ?? '';
+		$this->assertNotEmpty($etag, 'Expected ETag header on GET response');
+
+		$update = $this->putEventJson($id, $this->eventPayload($uid, 'Header Precedence Updated'), $this->ownerUser(), [
+			'If-Match' => $etag,
+			'If-Schedule-Tag-Match' => '"stale-schedule-tag"',
+		]);
+		$this->assertHttpStatus([200, 204], $update);
+
+		$this->assertEquals('Header Precedence Updated', $this->currentTitle($id), 'Event should have been updated');
+	}
+}

--- a/calendar/tests/REST/PutValidationAclTest.php
+++ b/calendar/tests/REST/PutValidationAclTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * REST API validation and ACL tests.
+ *
+ * REST (JSON / JsCalendar) equivalent of
+ * calendar/tests/CalDAV/PutValidationAclTest.php.
+ *
+ * Instead of a malformed iCalendar PUT and a foreign-calendar PUT, this uses a
+ * malformed JSON POST and a foreign-calendar POST against the REST API.
+ *
+ * @package calendar
+ * @subpackage tests
+ * @license http://opensource.org/licenses/gpl-license.php GPL - GNU General Public License
+ */
+
+namespace EGroupware\calendar\REST;
+
+require_once __DIR__.'/../../../api/tests/RestBase.php';
+
+use EGroupware\Api\RestBase;
+use GuzzleHttp\RequestOptions;
+
+class PutValidationAclTest extends RestBase
+{
+	protected const OTHER_USER = 'calendar_rest_other';
+	protected const EVENT_FIXTURE = __DIR__.'/fixtures/create-read-delete-event.json.tpl';
+
+	public static function setUpBeforeClass() : void
+	{
+		parent::setUpBeforeClass();
+		$data = [];
+		self::createUser(self::OTHER_USER, $data);
+	}
+
+	protected function ownerUser() : string
+	{
+		$this->assertNotEmpty($GLOBALS['EGW_USER'], 'EGW_USER must be configured for REST tests');
+		return $GLOBALS['EGW_USER'];
+	}
+
+	/**
+	 * Build a valid JsEvent payload from the fixture, with a unique title to find it again.
+	 */
+	protected function eventPayload(string $uid) : array
+	{
+		$template = file_get_contents(self::EVENT_FIXTURE);
+		$this->assertNotFalse($template, 'Unable to load event fixture');
+		$event = json_decode(strtr($template, ['{{UID}}' => $uid]), true);
+		$this->assertIsArray($event, 'Event fixture is not valid JSON');
+		$event['title'] = $uid;
+		return $event;
+	}
+
+	/**
+	 * Malformed JSON payload on the calendar collection must be rejected.
+	 *
+	 * Setup:
+	 * - POST a syntactically broken JSON body to the user's calendar collection.
+	 *
+	 * Pass criteria:
+	 * - POST returns a client error (400 / 415 / 422); the broken payload is not
+	 *   silently stored.
+	 */
+	public function testPostRejectsMalformedJson()
+	{
+		$response = $this->getClient($this->ownerUser())->post($this->url($this->calendarCollection($this->ownerUser())), [
+			RequestOptions::HEADERS => $this->jsonHeaders(),
+			// truncated / invalid JSON
+			RequestOptions::BODY => '{ "@type": "Event", "title": "broken payload", "start": ',
+		]);
+
+		$this->assertHttpStatus([400, 415, 422], $response);
+	}
+
+	/**
+	 * User without ACL must not be able to create in another user's calendar.
+	 *
+	 * Setup:
+	 * - Create a secondary authenticated user without delegated calendar rights.
+	 * - POST a valid event into the owner's calendar collection as that user.
+	 *
+	 * Pass criteria:
+	 * - Foreign POST is denied with HTTP 403.
+	 * - The event does not show up in the owner's calendar (collection search by
+	 *   its unique title returns no responses).
+	 */
+	public function testPostDeniedForForeignCalendarWithoutAcl()
+	{
+		$uid = $this->makeUid('calendar-rest-acl-denied');
+
+		$response = $this->getClient(self::OTHER_USER)->post($this->url($this->calendarCollection($this->ownerUser())), [
+			RequestOptions::HEADERS => $this->jsonHeaders(['Prefer' => 'return=representation']),
+			RequestOptions::BODY => $this->jsonBody($this->eventPayload($uid)),
+		]);
+		$this->assertHttpStatus(403, $response);
+
+		// owner must not see an event with that unique title
+		$owner_collection = $this->getClient($this->ownerUser())->get($this->url($this->calendarCollection($this->ownerUser())), [
+			RequestOptions::HEADERS => $this->jsonHeaders(),
+			RequestOptions::QUERY => ['filters' => ['search' => $uid]],
+		]);
+		$this->assertHttpStatus(200, $owner_collection);
+		$this->assertEmpty($this->jsonDecode($owner_collection)['responses'] ?? [],
+			'Foreign event must not have been created in the owner calendar');
+	}
+}

--- a/calendar/tests/REST/README.md
+++ b/calendar/tests/REST/README.md
@@ -1,0 +1,54 @@
+# Calendar REST API tests
+
+REST (JSON / [JsCalendar](https://datatracker.ietf.org/doc/html/rfc8984)) counterparts of the
+CalDAV tests in [`../CalDAV`](../CalDAV). They exercise the same EGroupware `groupdav.php`
+endpoint, but use the REST API instead of WebDAV/CalDAV requests.
+
+See [`doc/REST-CalDAV-CardDAV/Calendar.md`](../../../doc/REST-CalDAV-CardDAV/Calendar.md) for the
+REST API documentation.
+
+## How REST differs from CalDAV here
+
+| | CalDAV | REST |
+|---|---|---|
+| Content | `text/calendar` (iCalendar) | `application/json` (JsCalendar) |
+| Create | `PUT /<user>/calendar/<uid>.ics` | `POST /<user>/calendar/` (Location/ETag give the new id) |
+| Resource URL | `/<user>/calendar/<uid>.ics` | `/<user>/calendar/<cal_id>` (numeric id, no `.ics`) |
+| Read | `GET …` returns iCal | `GET …` with `Accept: application/json` returns JsEvent |
+| Delete | `DELETE …` | `DELETE …` **must** send `Accept: application/json` |
+| Discovery | `PROPFIND` on principal | `GET` on the collection |
+
+The server tells REST and CalDAV requests apart via the `Content-Type` (POST/PUT/PATCH) or
+`Accept` (GET/DELETE) header — see `Api\CalDAV::isJSON()`.
+
+## Base class
+
+The shared base class is [`api/tests/RestBase.php`](../../../api/tests/RestBase.php). It extends
+`Api\CalDAVTest` to reuse the user/ACL setup, authentication, cleanup and HTTP-status assertions,
+and adds JSON request/assertion helpers (`postEvent()`, `putEventJson()`, `patchEventJson()`,
+`getEventJson()`, `deleteEvent()`, `assertParticipationStatus()`, …).
+
+## Tests in this directory
+
+- `CreateReadDeleteTest` — create (POST), read (GET), delete (DELETE) and the no-auth/404 cases.
+- `PutPreconditionTest` — `If-Match` / `If-Schedule-Tag-Match` preconditions on PUT.
+- `PutValidationAclTest` — malformed-JSON rejection and foreign-calendar ACL denial.
+- `SingleDeleteTest` — organizer/attendee delete & reject semantics incl. the
+  `User-Agent: CalDAVSynchronizer` special case.
+
+## Not yet covered
+
+The CalDAV `IcalSyncTest` and `RecurrenceExceptionParticipantTest` are **not** adapted here yet,
+because the REST API currently rejects creating/modifying recurring events
+(`JsCalendar::parseEvent()` throws *"Creating or modifying recurring events is NOT (yet)
+implemented!"* for `recurrenceRules` / `recurrenceOverrides`). Once that is implemented — or as
+*not-implemented* assertions — they can be added.
+
+## Running
+
+```
+vendor/bin/phpunit -c doc/phpunit.xml --filter 'EGroupware\\calendar\\REST'
+```
+
+They are integration tests and need a running EGroupware instance reachable at `EGW_URL`
+(see `doc/phpunit.xml`), exactly like the CalDAV tests.

--- a/calendar/tests/REST/SingleDeleteTest.php
+++ b/calendar/tests/REST/SingleDeleteTest.php
@@ -1,0 +1,344 @@
+<?php
+/**
+ * REST API tests: DELETE requests for non-series events by organizer and attendees.
+ *
+ * REST (JSON / JsCalendar) equivalent of
+ * calendar/tests/CalDAV/SingleDeleteTest.php.
+ *
+ * The event is created with a POST of a JsEvent (organizer + attendees as
+ * participants referenced by their numeric account-id), and afterwards deleted
+ * via REST DELETE requests addressing the shared numeric cal_id in the
+ * respective user's calendar collection. Participant status is verified on the
+ * returned JsEvent ("participationStatus": "declined") instead of the iCal
+ * "PARTSTAT=DECLINED".
+ *
+ * The delete/reject and ACL semantics are implemented in the shared
+ * calendar_groupdav::delete() handler, so they behave identically for REST and
+ * CalDAV requests (incl. the "User-Agent: CalDAVSynchronizer" special case).
+ *
+ * @package calendar
+ * @subpackage tests
+ * @license http://opensource.org/licenses/gpl-license.php GPL - GNU General Public License
+ * @covers \calendar_groupdav::delete()
+ * @uses   \calendar_groupdav::put()
+ * @uses   \calendar_groupdav::get()
+ */
+
+namespace EGroupware\calendar\REST;
+
+require_once __DIR__.'/../../../api/tests/RestBase.php';
+
+use EGroupware\Api\RestBase;
+use EGroupware\Api\Acl;
+use GuzzleHttp\RequestOptions;
+
+class SingleDeleteTest extends RestBase
+{
+	protected const BOSS_MAIL = 'boss@example.org';
+	protected const SECRETARY_MAIL = 'secretary@example.org';
+	protected const OTHER_MAIL = 'other@example.org';
+
+	/**
+	 * account_id of the created test users, keyed by account_lid
+	 *
+	 * @var array<string,int>
+	 */
+	protected static $ids = [];
+
+	/**
+	 * Create the test users (boss, secretary, other) incl. ACL.
+	 *
+	 * secretary gets full rights on boss's calendar - this mirrors exactly the
+	 * grant CalDAVTest::createUsersACL() would issue, but we create the users
+	 * directly to capture their account-ids for building participant objects.
+	 */
+	public static function setUpBeforeClass() : void
+	{
+		parent::setUpBeforeClass();
+
+		$boss = [];
+		self::$ids['boss'] = self::createUser('boss', $boss);
+		$secretary = [];
+		self::$ids['secretary'] = self::createUser('secretary', $secretary);
+		$other = [];
+		self::$ids['other'] = self::createUser('other', $other);
+
+		// secretary gets full rights on boss's calendar
+		self::addAcl('calendar', self::$ids['secretary'], 'boss', Acl::READ|Acl::ADD|Acl::EDIT|Acl::DELETE);
+	}
+
+	/**
+	 * Build a participant object referenced by numeric account-id.
+	 */
+	protected function participant(string $email, array $roles, string $status) : array
+	{
+		return [
+			'@type' => 'Participant',
+			'email' => $email,
+			'kind'  => 'individual',
+			'roles' => $roles,
+			'participationStatus' => $status,
+		];
+	}
+
+	/**
+	 * Build a non-recurring JsEvent with the given organizer + attendee participants.
+	 *
+	 * @param string $uid
+	 * @param string $title
+	 * @param array $participants account_id => participant object
+	 * @return array JsEvent
+	 */
+	protected function buildEvent(string $uid, string $title, array $participants) : array
+	{
+		return [
+			'@type'    => 'Event',
+			'uid'      => $uid,
+			'title'    => $title,
+			'start'    => '2030-01-01T20:00:00',
+			'timeZone' => 'Europe/Berlin',
+			'duration' => 'PT1H',
+			'participants' => $participants,
+		];
+	}
+
+	/**
+	 * Create an event as $organizer (POST to their collection) and return the numeric cal_id.
+	 */
+	protected function createInvitation(string $organizer, array $event)
+	{
+		$response = $this->postEvent($event, $organizer);
+		$this->assertHttpStatus([200, 201], $response, "Create event as $organizer");
+		$id = $this->idFromResponse($response);
+		$this->assertNotEmpty($id, 'No id returned for created event');
+		return $id;
+	}
+
+	/**
+	 * DELETE $path_user's view of an event, authenticated as $auth_user.
+	 */
+	protected function deleteAs(string $auth_user, string $path_user, $id, array $headers=[]) : \Psr\Http\Message\ResponseInterface
+	{
+		return $this->getClient($auth_user)->delete($this->url($this->eventResource($path_user, $id)), [
+			RequestOptions::HEADERS => $this->jsonHeaders($headers),
+		]);
+	}
+
+	/**
+	 * GET $path_user's view of an event, authenticated as $auth_user.
+	 */
+	protected function getAs(string $auth_user, string $path_user, $id) : \Psr\Http\Message\ResponseInterface
+	{
+		return $this->getClient($auth_user)->get($this->url($this->eventResource($path_user, $id)), [
+			RequestOptions::HEADERS => $this->jsonHeaders(),
+		]);
+	}
+
+	/**
+	 * Verify the test users' calendar collections are reachable (REST discovery).
+	 *
+	 * Pass criteria:
+	 * - GET on each user's calendar collection returns HTTP 200.
+	 */
+	public function testCollections()
+	{
+		foreach(['boss', 'secretary', 'other'] as $user)
+		{
+			$response = $this->getAs($user, $user, '');
+			$this->assertHttpStatus(200, $response, "Collection of $user reachable");
+		}
+	}
+
+	/**
+	 * Secretary deletes in boss's calendar an event boss is invited to (as attendee).
+	 *
+	 * Setup:
+	 * - Create event where organizer is "other" and boss is attendee.
+	 *
+	 * Pass criteria:
+	 * - Secretary deleting in boss's (attendee) calendar rejects/declines (204)
+	 *   without removing the organizer copy.
+	 * - Secretary cannot delete the organizer copy (403).
+	 * - Boss can delete/reject in both attendee and organizer views (204).
+	 * - Organizer can finally delete the event and GET then returns 404.
+	 */
+	public function testSecretaryDeletesBossAttendee()
+	{
+		$uid = $this->makeUid('rest-single-delete-boss-attendee');
+		$event = $this->buildEvent($uid, 'Single delete: boss attendee', [
+			(string)self::$ids['other'] => $this->participant(self::OTHER_MAIL, ['owner' => true, 'chair' => true], 'accepted'),
+			(string)self::$ids['boss']  => $this->participant(self::BOSS_MAIL, ['attendee' => true], 'needs-action'),
+		]);
+
+		// create invitation by organizer "other"
+		$cal_id = $this->createInvitation('other', $event);
+
+		// secretary deletes event in boss's calendar
+		$response = $this->deleteAs('secretary', 'boss', $cal_id);
+		$this->assertHttpStatus(204, $response, 'Secretary delete/rejects for boss');
+
+		// organizer checks event still exists and boss declined
+		$response = $this->getAs('other', 'other', $cal_id);
+		$this->assertHttpStatus(200, $response, 'Check event still exists after DELETE in attendee calendar');
+		$this->assertParticipationStatus($this->jsonDecode($response), self::BOSS_MAIL, 'declined',
+			'Boss should have declined the invitation');
+
+		// secretary tries to delete event in organizer's calendar
+		$response = $this->deleteAs('secretary', 'other', $cal_id);
+		$this->assertHttpStatus(403, $response, 'Secretary not allowed to delete for organizer');
+
+		// boss deletes/rejects event in his calendar
+		$response = $this->deleteAs('boss', 'boss', $cal_id);
+		$this->assertHttpStatus(204, $response, 'Boss deletes/rejects in his calendar');
+
+		// boss deletes/rejects event in organizer's calendar
+		$response = $this->deleteAs('boss', 'other', $cal_id);
+		$this->assertHttpStatus(204, $response, 'Boss deletes/rejects in organizer calendar');
+
+		// organizer deletes event
+		$response = $this->deleteAs('other', 'other', $cal_id);
+		$this->assertHttpStatus(204, $response, 'Organizer deletes');
+
+		// organizer checks event deleted
+		$response = $this->getAs('other', 'other', $cal_id);
+		$this->assertHttpStatus(404, $response, 'Check event deleted by organizer');
+	}
+
+	/**
+	 * Secretary deletes for boss, who is the organizer of the event.
+	 *
+	 * Setup:
+	 * - Create event where boss is organizer and other is attendee.
+	 *
+	 * Pass criteria:
+	 * - Attendee can delete/reject in his calendar (204).
+	 * - Secretary (with delegated rights) can delete the organizer event (204).
+	 * - Organizer copy is gone afterwards (404).
+	 */
+	public function testSecretaryDeletesBossOrganizer()
+	{
+		$uid = $this->makeUid('rest-single-delete-boss-organizer');
+		$event = $this->buildEvent($uid, 'Single delete: boss organizer', [
+			(string)self::$ids['boss']  => $this->participant(self::BOSS_MAIL, ['owner' => true, 'chair' => true], 'accepted'),
+			(string)self::$ids['other'] => $this->participant(self::OTHER_MAIL, ['attendee' => true], 'needs-action'),
+		]);
+
+		$cal_id = $this->createInvitation('boss', $event);
+
+		// attendee deletes/rejects event in his calendar
+		$response = $this->deleteAs('other', 'other', $cal_id);
+		$this->assertHttpStatus(204, $response, 'Attendee deletes/rejects');
+
+		// secretary deletes event in boss's calendar
+		$response = $this->deleteAs('secretary', 'boss', $cal_id);
+		$this->assertHttpStatus(204, $response, 'Secretary deletes for boss');
+
+		// boss (organizer) checks event deleted
+		$response = $this->getAs('boss', 'boss', $cal_id);
+		$this->assertHttpStatus(404, $response, 'Check event deleted by secretary');
+	}
+
+	/**
+	 * Organizer (boss) can delete the event in his calendar.
+	 *
+	 * Setup:
+	 * - Create event where boss is organizer and other is attendee.
+	 *
+	 * Pass criteria:
+	 * - Organizer delete returns 204.
+	 * - Event is removed for both organizer and attendee views (404).
+	 */
+	public function testOrganizerDeletes()
+	{
+		$uid = $this->makeUid('rest-single-delete-organizer');
+		$event = $this->buildEvent($uid, 'Single delete: organizer deletes', [
+			(string)self::$ids['boss']  => $this->participant(self::BOSS_MAIL, ['owner' => true, 'chair' => true], 'accepted'),
+			(string)self::$ids['other'] => $this->participant(self::OTHER_MAIL, ['attendee' => true], 'needs-action'),
+		]);
+
+		$cal_id = $this->createInvitation('boss', $event);
+
+		// organizer deletes event in his calendar
+		$response = $this->deleteAs('boss', 'boss', $cal_id);
+		$this->assertHttpStatus(204, $response, 'Organizer deletes');
+
+		// organizer checks event deleted
+		$response = $this->getAs('boss', 'boss', $cal_id);
+		$this->assertHttpStatus(404, $response, 'Check event deleted by organizer');
+
+		// attendee checks event deleted
+		$response = $this->getAs('other', 'other', $cal_id);
+		$this->assertHttpStatus(404, $response, 'Check event deleted by organizer');
+	}
+
+	/**
+	 * Secretary as attendee deletes the event in her own calendar.
+	 *
+	 * Setup:
+	 * - Create event where boss is organizer and secretary is attendee.
+	 *
+	 * Pass criteria:
+	 * - Secretary delete in her attendee calendar returns 204.
+	 * - Organizer copy is deleted (404).
+	 */
+	public function testSecretaryAttendeeDeletes()
+	{
+		$uid = $this->makeUid('rest-single-delete-secretary-attendee');
+		$event = $this->buildEvent($uid, 'Single delete: secretary attendee', [
+			(string)self::$ids['boss']      => $this->participant(self::BOSS_MAIL, ['owner' => true, 'chair' => true], 'accepted'),
+			(string)self::$ids['secretary'] => $this->participant(self::SECRETARY_MAIL, ['attendee' => true], 'needs-action'),
+		]);
+
+		$cal_id = $this->createInvitation('boss', $event);
+
+		// secretary deletes in her calendar
+		$response = $this->deleteAs('secretary', 'secretary', $cal_id);
+		$this->assertHttpStatus(204, $response, 'Secretary (attendee) deletes');
+
+		// organizer checks it's really deleted
+		$response = $this->getAs('boss', 'boss', $cal_id);
+		$this->assertHttpStatus(404, $response, 'Check event deleted by secretary');
+	}
+
+	/**
+	 * Secretary as attendee deletes the event using "User-Agent: CalDAVSynchronizer".
+	 *
+	 * Setup:
+	 * - Create event where boss is organizer and secretary is attendee.
+	 * - Execute delete with "User-Agent: CalDAVSynchronizer".
+	 *
+	 * Pass criteria:
+	 * - Attendee delete/reject returns 204, but the organizer copy remains (200)
+	 *   with secretary declined (CalDAVSynchronizer does not distinguish reject
+	 *   from delete).
+	 * - Organizer delete with the same user-agent still deletes the event (404).
+	 */
+	public function testSecretaryAttendeeDeletesCalDAVSynchronizer()
+	{
+		$uid = $this->makeUid('rest-single-delete-secretary-attendee-sync');
+		$event = $this->buildEvent($uid, 'Single delete: secretary attendee (sync)', [
+			(string)self::$ids['boss']      => $this->participant(self::BOSS_MAIL, ['owner' => true, 'chair' => true], 'accepted'),
+			(string)self::$ids['secretary'] => $this->participant(self::SECRETARY_MAIL, ['attendee' => true], 'needs-action'),
+		]);
+
+		$cal_id = $this->createInvitation('boss', $event);
+
+		// secretary deletes in her calendar with CalDAVSynchronizer user-agent
+		$response = $this->deleteAs('secretary', 'secretary', $cal_id, ['User-Agent' => 'CalDAVSynchronizer']);
+		$this->assertHttpStatus(204, $response, 'Secretary (attendee) deletes/rejects');
+
+		// organizer checks it's NOT deleted, only declined
+		$response = $this->getAs('boss', 'boss', $cal_id);
+		$this->assertHttpStatus(200, $response, 'Check event NOT deleted by secretary');
+		$this->assertParticipationStatus($this->jsonDecode($response), self::SECRETARY_MAIL, 'declined',
+			'Secretary should have declined the invitation');
+
+		// organizer deletes in his calendar with CalDAVSynchronizer user-agent
+		$response = $this->deleteAs('boss', 'boss', $cal_id, ['User-Agent' => 'CalDAVSynchronizer']);
+		$this->assertHttpStatus(204, $response, 'Organizer deletes');
+
+		// organizer checks it's deleted
+		$response = $this->getAs('boss', 'boss', $cal_id);
+		$this->assertHttpStatus(404, $response, 'Check event deleted by organizer');
+	}
+}

--- a/calendar/tests/REST/fixtures/create-read-delete-event.json.tpl
+++ b/calendar/tests/REST/fixtures/create-read-delete-event.json.tpl
@@ -1,0 +1,14 @@
+{
+    "@type": "Event",
+    "uid": "{{UID}}",
+    "title": "Tonight",
+    "start": "2030-01-01T20:00:00",
+    "timeZone": "Europe/Berlin",
+    "duration": "PT1H",
+    "locations": {
+        "1": {
+            "@type": "Location",
+            "name": "Somewhere"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a REST (JSON / JsCalendar) test directory `calendar/tests/REST/`, adapting the existing CalDAV tests in `calendar/tests/CalDAV/` to exercise the REST API instead of WebDAV/CalDAV requests, against the same `groupdav.php` endpoint.

## What's included (core four)

- `api/tests/RestTest.php` — shared base class extending `Api\CalDAVTest`, reusing its user/ACL setup, auth, cleanup and HTTP-status assertions, and adding JSON request/assertion helpers (POST/PUT/PATCH/GET/DELETE, `assertParticipationStatus()`).
- `calendar/tests/REST/CreateReadDeleteTest.php` — create (POST), read & delete by numeric id, collection discovery, 401/404 cases.
- `calendar/tests/REST/PutPreconditionTest.php` — `If-Match` / `If-Schedule-Tag-Match` preconditions on PUT.
- `calendar/tests/REST/PutValidationAclTest.php` — malformed-JSON rejection and foreign-calendar ACL denial.
- `calendar/tests/REST/SingleDeleteTest.php` — organizer/attendee delete & reject semantics incl. the `User-Agent: CalDAVSynchronizer` case.
- `calendar/tests/REST/fixtures/` + `README.md`.
- `doc/phpunit.xml` — excludes the `RestTest.php` base from the Api suite (mirrors the existing `CalDAVTest.php` exclude); the `Apps` suite auto-discovers `calendar/tests/REST/`.

## Notes

- REST addresses resources by numeric `cal_id` (not `<uid>.ics`); events are created via POST to the collection, and the REST API is selected via `Content-Type` / `Accept: application/json`.
- `IcalSyncTest` and `RecurrenceExceptionParticipantTest` are intentionally not adapted yet: `JsCalendar::parseEvent()` currently rejects creating/modifying recurring events. They can follow once that is supported (or as not-implemented assertions).
- These are integration tests and require a running EGroupware instance reachable at `EGW_URL`, like the CalDAV tests.
