### PR TITLE
Addressbook: fix REST/JSON contact creation always using personal addressbook

### DIFF
--- a/addressbook/inc/class.addressbook_groupdav.inc.php
+++ b/addressbook/inc/class.addressbook_groupdav.inc.php
@@ -855,7 +855,8 @@ class addressbook_groupdav extends Api\CalDAV\Handler
 				$contact['owner'] = $user;
 			}
 			// check if default addressbook is synced and not Api\Accounts, if not use (always synced) personal addressbook
-			elseif(!$this->bo->default_addressbook || !in_array($this->bo->default_addressbook,$this->home_set_pref))
+			// for JSON/REST requests skip the home_set_pref check — always honour the user's configured default addressbook
+			elseif(!$this->bo->default_addressbook || (!$is_json && !in_array($this->bo->default_addressbook,$this->home_set_pref)))
 			{
 				$contact['owner'] = $GLOBALS['egw_info']['user']['account_id'];
 			}


### PR DESCRIPTION
## Summary

- Skip the `home_set_pref` (CardDAV sync home-set) check when a new contact is created via REST/JSON API
- The check was designed for CardDAV clients that only sync address books in the home set; for REST calls it incorrectly fell back to the personal addressbook even when the user had a group addressbook set as default
- Fixes `aiassist.signature2contact` creating contacts in the personal addressbook instead of the user's configured default (e.g. "EGroupware Gruppe")

## Test plan

- Configure a group addressbook (e.g. "EGroupware Gruppe") as the default in Addressbook → Preferences → "Default addressbook for new contacts"
- Run the signature2contact AI prompt on a mail
- Verify the new contact lands in the group addressbook, not personal