### PR TITLE
calendar: fix REST PutValidationAclTest (filters[search] 500 on master)

### DIFF
--- a/calendar/tests/REST/PutValidationAclTest.php
+++ b/calendar/tests/REST/PutValidationAclTest.php
@@ -81,8 +81,8 @@ class PutValidationAclTest extends RestBase
 	 *
 	 * Pass criteria:
 	 * - Foreign POST is denied with HTTP 403.
-	 * - The event does not show up in the owner's calendar (collection search by
-	 *   its unique title returns no responses).
+	 * - The event does not show up in the owner's calendar: a collection GET
+	 *   over the event's time-range does not return its unique title.
 	 */
 	public function testPostDeniedForForeignCalendarWithoutAcl()
 	{
@@ -94,13 +94,14 @@ class PutValidationAclTest extends RestBase
 		]);
 		$this->assertHttpStatus(403, $response);
 
-		// owner must not see an event with that unique title
+		// owner must not see an event with that unique title; query the time-range
+		// the fixture event would fall into (start 2030-01-01T20:00 Europe/Berlin)
 		$owner_collection = $this->getClient($this->ownerUser())->get($this->url($this->calendarCollection($this->ownerUser())), [
 			RequestOptions::HEADERS => $this->jsonHeaders(),
-			RequestOptions::QUERY => ['filters' => ['search' => $uid]],
+			RequestOptions::QUERY => ['filters' => ['start' => '20300101T000000Z', 'end' => '20300102T000000Z']],
 		]);
 		$this->assertHttpStatus(200, $owner_collection);
-		$this->assertEmpty($this->jsonDecode($owner_collection)['responses'] ?? [],
-			'Foreign event must not have been created in the owner calendar');
+		$titles = array_column(array_values($this->jsonDecode($owner_collection)['responses'] ?? []), 'title');
+		$this->assertNotContains($uid, $titles, 'Foreign event must not have been created in the owner calendar');
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the `phpunit` failure on `master` introduced by #246.

`calendar/tests/REST/PutValidationAclTest::testPostDeniedForForeignCalendarWithoutAcl`
verified "the foreign event was not created" with a bare-string
`filters[search]` collection query. The CalDAV REST collection handler does not
support that form: a string `filters[search]` falls through to
`calendar_groupdav::_report_filters()`, which iterates the filters expecting
array entries (`$filter['name']`) and fatals on the string — returning **HTTP
500** (this is what @nathangray reproduced on #246).

This switches the verification to a `filters[start]/[end]` **time-range** query
over the event's date — a filter that *is* implemented (`CalDAV.php` converts it
to a `time-range` filter handled by `_report_filters()`) — and asserts the
event's unique title is not among the returned events. The `403` ACL-denial
assertion is unchanged.

## Verification

Ran `calendar/tests/REST` against a freshly installed master instance
(`php -S` + phpunit, as the CI does): **19 tests, 118 assertions, all green**,
including this test.

## Note

The underlying bug — a documented bare-string `filters[search]` GET parameter
crashing the calendar REST collection with a 500 — is left for a separate fix;
this PR only stops the test from depending on the unsupported form so `master`
CI goes green again.
