### PR TITLE
Enhance popup styles with max-height and overflow

### DIFF
--- a/kdots/css/src/popups.less
+++ b/kdots/css/src/popups.less
@@ -4,6 +4,8 @@
   height: 100%;
    */
   padding: 0 var(--sl-spacing-small);
+  max-height: 98vh; //If popup is not big enough make sure we can still reach bottom buttons
+  overflow: auto; //To trigger a scrollbar when user interface is zoomed (desktop or browser).
 
   .dialogHeader, .dialogFooter, .dialogFooterToolbar {
 	// Set border a little thicker & darker


### PR DESCRIPTION
Display problem on the calendar full edit dialog for the new event when user interface is zoomed (desktop or browser) See topic https://help.egroupware.org/t/display-problem-on-the-calendar-full-edit-dialog-for-the-new-events/79255

Was already patch by last PR on Pixelegg template : https://github.com/EGroupware/egroupware/pull/203/changes/e944993c15335eb1d11256c56c7128c43e6aaa44