### PR TITLE
Fix/rest api openwebui integration

### DIFF
--- a/api/src/Db.php
+++ b/api/src/Db.php
@@ -1724,7 +1724,12 @@ class Db
 					if (strpos($key, '.') !== false) list(, $col) = explode('.', $key);
 					if (!isset($column_definitions[$col]))
 					{
-						throw new Db\Exception\InvalidSql("db::column_data_implode('$glue',".print_r($array,True).",'$use_key',".print_r($only,True).",<pre>".print_r($column_definitions,True)."</pre><b>nothing known about column '$key'!</b>");
+						// the full arrays are valuable for debugging, but this exception message is echoed
+						// to REST/CalDAV clients, so keep the table schema and the given values out of it
+						error_log(__METHOD__."('$glue',".print_r($array,True).",'$use_key',".print_r($only,True).
+							") nothing known about column '$key', known columns: ".
+							implode(', ', array_keys((array)$column_definitions)));
+						throw new Db\Exception\InvalidSql("nothing known about column '$key'!");
 					}
 				}
 				$column_type = is_array($column_definitions) ? ($column_definitions[$col]['type'] ?? false) : False;

--- a/calendar/inc/class.calendar_groupdav.inc.php
+++ b/calendar/inc/class.calendar_groupdav.inc.php
@@ -544,6 +544,85 @@ class calendar_groupdav extends Api\CalDAV\Handler
 	}
 
 	/**
+	 * Apply the JSON/REST API filters to the calendar search parameters
+	 *
+	 * Unlike the CalDAV XML filters handled in _report_filters(), these arrive as a plain
+	 * name => value array. filters[start] / filters[end] have already been turned into a
+	 * synthetic time-range element under an integer key by Api\CalDAV::jsonIndex().
+	 *
+	 * Entries outside filters[start]/filters[end] keep the collection's default -100/+365 day
+	 * window, same as an unfiltered listing.
+	 *
+	 * @param array $filters filters from the request
+	 * @param array& $cal_filters
+	 * @throws Api\Exception 400 for an invalid linked-filter
+	 */
+	private function jsonReportFilters(array $filters, array &$cal_filters)
+	{
+		$search = $linked_ids = null;
+
+		foreach($filters as $name => $value)
+		{
+			if (!is_string($name))
+			{
+				if (is_array($value) && ($value['name'] ?? null) === 'time-range')
+				{
+					if (!empty($value['attrs']['start']))
+					{
+						$cal_filters['start'] = $this->vCalendar->_parseDateTime($value['attrs']['start']);
+					}
+					if (!empty($value['attrs']['end']))
+					{
+						$cal_filters['end'] = $this->vCalendar->_parseDateTime($value['attrs']['end']);
+					}
+				}
+				continue;
+			}
+			switch($name)
+			{
+				case 'search':
+					// string: free-text over cal_title, cal_description and cal_location
+					// array: <db-column> => <value>, integer keys stripped as they'd be used as SQL
+					$search = is_array($value) ?
+						array_filter($value, static fn($key) => !is_int($key), ARRAY_FILTER_USE_KEY) : $value;
+					break;
+
+				case 'linked':
+					if (!preg_match('/^([a-z_]+):(\d+)$/i', $value, $matches) ||
+						!isset($GLOBALS['egw_info']['user']['apps'][$matches[1]]) || (int)$matches[2] <= 0)
+					{
+						throw new Api\Exception("Invalid linked-filter '$value', should be '<app-name>:<nummeric-ID>'!", 400);
+					}
+					// [0] to return nothing instead of everything, if there are no links
+					$linked_ids = Api\Link::get_links($matches[1], $matches[2], 'calendar') ?: [0];
+					break;
+
+				default:
+					$this->caldav->log(__METHOD__."() unknown filter '$name' --> ignored");
+					break;
+			}
+		}
+
+		// calendar_bo::search() only understands one "query": either a free-text string searched over
+		// title/description/location, or an array of <db-column> => <value>. sql_filter is not usable
+		// here, calendar_bo::search() deliberately overwrites it from its own 2nd argument.
+		if (isset($search) && isset($linked_ids) && !is_array($search))
+		{
+			throw new Api\Exception("filters[linked] can not be combined with a free-text filters[search] for calendar", 400);
+		}
+		if (isset($linked_ids))
+		{
+			$search = (array)($search ?? []);
+			// table-qualified, cal_id exists in egw_cal and egw_cal_user
+			$search['egw_cal.cal_id'] = $linked_ids;
+		}
+		if (isset($search))
+		{
+			$cal_filters['query'] = $search;
+		}
+	}
+
+	/**
 	 * Process the filters from the CalDAV REPORT request
 	 *
 	 * @param array $options
@@ -554,7 +633,13 @@ class calendar_groupdav extends Api\CalDAV\Handler
 	 */
 	function _report_filters($options, &$cal_filters, $id, &$nresults)
 	{
-		if ($options['filters'])
+		// JSON/REST API: filters arrive as a plain name => value array, not as CalDAV XML elements,
+		// so they would all fall through the switch below and be silently ignored
+		if (Api\CalDAV::isJSON() && !empty($options['filters']) && is_array($options['filters']))
+		{
+			$this->jsonReportFilters($options['filters'], $cal_filters);
+		}
+		elseif ($options['filters'])
 		{
 			// unset default start & end
 			$cal_start = $cal_filters['start']; unset($cal_filters['start']);

--- a/doc/openapi/addressbook.json
+++ b/doc/openapi/addressbook.json
@@ -31,7 +31,7 @@
           "Addressbook"
         ],
         "summary": "Search all addressbooks",
-        "description": "Search in all addressbooks the user has access to. Supports searching, filtering, pagination, and custom property selection.",
+        "description": "Search all addressbooks the user has access to, ordered by contact ID (oldest first); pass filters[order]=contact_modified DESC for newest first. Use filters[search] for a free-text pattern. To bound the response size, send sync-token= (empty) together with nresults=20; the response then carries a more-results flag and a sync-token for the next chunk.",
         "operationId": "searchContacts",
         "parameters": [
           {
@@ -44,6 +44,9 @@
             "$ref": "#/components/parameters/nresults"
           },
           {
+            "$ref": "#/components/parameters/filters_order"
+          },
+          {
             "$ref": "#/components/parameters/filters_search"
           },
           {
@@ -52,7 +55,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": [
@@ -146,7 +149,7 @@
       "get": {
         "tags": ["Addressbook"],
         "summary": "List or search contacts in the given users addressbook",
-        "description": "Returns all contacts in the user's addressbook. Supports filtering, pagination, and custom property selection.",
+        "description": "Returns contacts from the user's addressbook, ordered by contact ID (oldest first); pass filters[order]=contact_modified DESC for newest first. To bound the response size, send sync-token= (empty) together with nresults=20; the response then carries a more-results flag and a sync-token for the next chunk.",
         "operationId": "listContacts",
         "parameters": [
           {
@@ -162,6 +165,9 @@
             "$ref": "#/components/parameters/nresults"
           },
           {
+            "$ref": "#/components/parameters/filters_order"
+          },
+          {
             "$ref": "#/components/parameters/filters_search"
           },
           {
@@ -170,7 +176,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": ["application/json", "application/pretty+json"]
@@ -273,7 +279,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": ["application/json", "application/pretty+json"]
@@ -485,7 +491,16 @@
         "schema": {
           "type": "integer"
         },
-        "description": "Limit number of responses (only for sync-collection)"
+        "description": "Limit the number of contacts returned. Only honored together with the sync-token parameter: send sync-token= (empty) plus nresults=N to receive at most N contacts, a \"more-results\": true flag when further contacts exist, and a sync-token to request the next chunk. Sent on its own, nresults has no effect."
+      },
+      "filters_order": {
+        "name": "filters[order]",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Sort order as '<db-column>' optionally followed by ' ASC' or ' DESC'. Defaults to 'egw_addressbook.contact_id' (oldest first). A table-qualified column such as egw_addressbook.<column> is also accepted. Example: filters[order]=n_family ASC"
       },
       "filters_search": {
         "name": "filters[search]",

--- a/doc/openapi/calendar.json
+++ b/doc/openapi/calendar.json
@@ -31,7 +31,7 @@
           "Calendar"
         ],
         "summary": "List all events of the user",
-        "description": "Returns all events in the user's calendar. Supports filtering, pagination, and custom property selection.",
+        "description": "Returns events from the user's calendar. Without filters[start]/filters[end] only events between 100 days in the past and 365 days in the future are returned. To bound the response size, send sync-token= (empty) together with nresults=20; the response then carries a more-results flag and a sync-token for the next chunk. If the question mentions any time period, resolve it to explicit YYYY-MM-DD dates and pass filters[start] and filters[end] as well.",
         "operationId": "listEvents",
         "parameters": [
           {
@@ -58,7 +58,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": [
@@ -169,7 +169,7 @@
       "get": {
         "tags": ["Calendar"],
         "summary": "List all events in a given users calendar",
-        "description": "Returns all events in the user's calendar. Supports filtering, pagination, and custom property selection.",
+        "description": "Returns events from the user's calendar. Without filters[start]/filters[end] only events between 100 days in the past and 365 days in the future are returned. To bound the response size, send sync-token= (empty) together with nresults=20; the response then carries a more-results flag and a sync-token for the next chunk. If the question mentions any time period, resolve it to explicit YYYY-MM-DD dates and pass filters[start] and filters[end] as well.",
         "operationId": "listUserEvents",
         "parameters": [
           {
@@ -199,7 +199,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": ["application/json", "application/pretty+json"]
@@ -319,7 +319,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": ["application/json", "application/pretty+json"]
@@ -457,7 +457,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": ["application/json"]
@@ -536,25 +536,27 @@
         "schema": {
           "type": "integer"
         },
-        "description": "Limit number of responses (only for sync-collection)"
+        "description": "Limit the number of events returned. Only honored together with the sync-token parameter: send sync-token= (empty) plus nresults=N to receive at most N events, a \"more-results\": true flag when further events exist, and a sync-token to request the next chunk. Sent on its own, nresults has no effect."
       },
       "filters_start": {
         "name": "filters[start]",
         "in": "query",
         "required": false,
         "schema": {
-          "type": "datetime"
+          "type": "string",
+          "format": "date"
         },
-        "description": "Start date of search. Example: filters[start]=2026-01-01"
+        "description": "Only return entries overlapping this start date, as YYYY-MM-DD (a full ISO 8601 date-time is also accepted). REQUIRED whenever the question refers to a time period: resolve phrases like 'this week', 'today' or 'next month' to explicit dates and pass them. Example: filters[start]=2026-01-01"
       },
       "filters_end": {
         "name": "filters[end]",
         "in": "query",
         "required": false,
         "schema": {
-          "type": "datetime"
+          "type": "string",
+          "format": "date"
         },
-        "description": "End date of search. Example: filters[start]=2026-02-01"
+        "description": "Only return entries overlapping this end date, as YYYY-MM-DD (a full ISO 8601 date-time is also accepted). Pass together with filters[start] for any time-bounded question. Example: filters[end]=2026-02-01"
       },
       "filters_search": {
         "name": "filters[search]",
@@ -563,7 +565,7 @@
         "schema": {
           "type": "string"
         },
-        "description": "Search pattern. Example: filters[search]=something"
+        "description": "Free-text pattern searched over event title, description and location. Cannot be combined with filters[linked]. Example: filters[search]=standup"
       },
       "filters_linked": {
         "name": "filters[linked]",

--- a/doc/openapi/infolog.json
+++ b/doc/openapi/infolog.json
@@ -29,7 +29,7 @@
       "get": {
         "tags": ["InfoLog"],
         "summary": "List all infolog entries",
-        "description": "Returns all infolog entries (tasks, notes, calls, etc.) for the user. Supports filtering, pagination, and custom property selection.",
+        "description": "Returns infolog entries (tasks, notes, calls, etc.) for the user, most recently modified first. filters[start]/filters[end] match entries whose start/due date overlaps the range. To bound the response size, send sync-token= (empty) together with nresults=20; the response then carries a more-results flag and a sync-token for the next chunk. If the question mentions any time period, resolve it to explicit YYYY-MM-DD dates and pass filters[start] and filters[end] as well.",
         "operationId": "listTasks",
         "parameters": [
           {
@@ -40,6 +40,9 @@
           },
           {
             "$ref": "#/components/parameters/nresults"
+          },
+          {
+            "$ref": "#/components/parameters/filters_order"
           },
           {
             "$ref": "#/components/parameters/filters_start"
@@ -56,7 +59,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": [
@@ -145,7 +148,7 @@
       "get": {
         "tags": ["InfoLog"],
         "summary": "List all infolog entries of a given user",
-        "description": "Returns all infolog entries (tasks, notes, calls, etc.) for the given user. Supports filtering, pagination, and custom property selection.",
+        "description": "Returns infolog entries (tasks, notes, calls, etc.) for the given user, most recently modified first. filters[start]/filters[end] match entries whose start/due date overlaps the range. To bound the response size, send sync-token= (empty) together with nresults=20; the response then carries a more-results flag and a sync-token for the next chunk. If the question mentions any time period, resolve it to explicit YYYY-MM-DD dates and pass filters[start] and filters[end] as well.",
         "operationId": "listUserTasks",
         "parameters": [
           {
@@ -159,6 +162,9 @@
           },
           {
             "$ref": "#/components/parameters/nresults"
+          },
+          {
+            "$ref": "#/components/parameters/filters_order"
           },
           {
             "$ref": "#/components/parameters/filters_start"
@@ -175,7 +181,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": ["application/json", "application/pretty+json"]
@@ -273,7 +279,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": ["application/json","application/pretty+json"]
@@ -469,25 +475,36 @@
         "schema": {
           "type": "integer"
         },
-        "description": "Limit number of responses (only for sync-collection)"
+        "description": "Limit the number of entries returned. Only honored together with the sync-token parameter: send sync-token= (empty) plus nresults=N to receive at most N entries, a \"more-results\": true flag when further entries exist, and a sync-token to request the next chunk. Sent on its own, nresults has no effect."
       },
       "filters_start": {
         "name": "filters[start]",
         "in": "query",
         "required": false,
         "schema": {
-          "type": "datetime"
+          "type": "string",
+          "format": "date"
         },
-        "description": "Start date of search. Example: filters[start]=2026-01-01"
+        "description": "Only return entries overlapping this start date, as YYYY-MM-DD (a full ISO 8601 date-time is also accepted). REQUIRED whenever the question refers to a time period: resolve phrases like 'this week', 'today' or 'next month' to explicit dates and pass them. Example: filters[start]=2026-01-01"
       },
       "filters_end": {
         "name": "filters[end]",
         "in": "query",
         "required": false,
         "schema": {
-          "type": "datetime"
+          "type": "string",
+          "format": "date"
         },
-        "description": "End date of search. Example: filters[start]=2026-02-01"
+        "description": "Only return entries overlapping this end date, as YYYY-MM-DD (a full ISO 8601 date-time is also accepted). Pass together with filters[start] for any time-bounded question. Example: filters[end]=2026-02-01"
+      },
+      "filters_order": {
+        "name": "filters[order]",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Sort order as '<db-column>' optionally followed by ' ASC' or ' DESC'. Defaults to 'info_datemodified DESC' (newest first). Example: filters[order]=info_enddate ASC"
       },
       "filters_search": {
         "name": "filters[search]",

--- a/doc/openapi/links.json
+++ b/doc/openapi/links.json
@@ -83,7 +83,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": [

--- a/doc/openapi/mail.json
+++ b/doc/openapi/mail.json
@@ -35,7 +35,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": ["application/json"]
@@ -484,7 +484,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": ["application/json"]
@@ -563,7 +563,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": ["application/json"]

--- a/doc/openapi/rag.json
+++ b/doc/openapi/rag.json
@@ -35,7 +35,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": ["application/json", "application/pretty+json"]
@@ -115,7 +115,7 @@
             "schema": {
               "type": "integer"
             },
-            "description": "Limit number of responses (only for sync-collection)"
+            "description": "Limit the number of results returned. Only honored together with the sync-token parameter: send sync-token= (empty) plus nresults=N to receive at most N results, a \"more-results\": true flag when further results exist, and a sync-token to request the next chunk. Sent on its own, nresults has no effect."
           }
         ],
         "responses": {

--- a/doc/openapi/timesheet.json
+++ b/doc/openapi/timesheet.json
@@ -32,7 +32,7 @@
         ],
         "operationId": "listTimesheets",
         "summary": "List all timesheets the current user has access too",
-        "description": "Returns all timesheets for the current user. Supports filtering, pagination, and custom property selection. To search use parameter 'filters[search]' set to your search pattern.",
+        "description": "Returns timesheets for the current user, ordered by timesheet ID (oldest first); pass filters[order]=ts_start DESC for newest first. Use filters[search] for a free-text pattern. Date-range filtering (filters[start]/filters[end]) is NOT supported for timesheets and returns HTTP 422. To bound the response size, send sync-token= (empty) together with nresults=20; the response then carries a more-results flag and a sync-token for the next chunk.",
         "parameters": [
           {
             "$ref": "#/components/parameters/props"
@@ -44,6 +44,9 @@
             "$ref": "#/components/parameters/nresults"
           },
           {
+            "$ref": "#/components/parameters/filters_order"
+          },
+          {
             "$ref": "#/components/parameters/filters_search"
           },
           {
@@ -52,7 +55,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": [
@@ -177,7 +180,7 @@
         ],
         "operationId": "listUserTimesheets",
         "summary": "List all timesheets for a given user",
-        "description": "Returns all timesheets for the specified user. Supports filtering, pagination, and custom property selection. To search use parameter 'filters[search]' set to your search pattern.",
+        "description": "Returns timesheets for the specified user, ordered by timesheet ID (oldest first); pass filters[order]=ts_start DESC for newest first. Use filters[search] for a free-text pattern. Date-range filtering (filters[start]/filters[end]) is NOT supported for timesheets and returns HTTP 422. To bound the response size, send sync-token= (empty) together with nresults=20; the response then carries a more-results flag and a sync-token for the next chunk.",
         "parameters": [
           {
             "$ref": "#/components/parameters/username"
@@ -192,6 +195,9 @@
             "$ref": "#/components/parameters/nresults"
           },
           {
+            "$ref": "#/components/parameters/filters_order"
+          },
+          {
             "$ref": "#/components/parameters/filters_search"
           },
           {
@@ -200,7 +206,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": [
@@ -336,7 +342,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": [
@@ -557,7 +563,16 @@
         "schema": {
           "type": "integer"
         },
-        "description": "Limit number of responses (only for sync-collection)"
+        "description": "Limit the number of timesheets returned. Only honored together with the sync-token parameter: send sync-token= (empty) plus nresults=N to receive at most N timesheets, a \"more-results\": true flag when further timesheets exist, and a sync-token to request the next chunk. Sent on its own, nresults has no effect."
+      },
+      "filters_order": {
+        "name": "filters[order]",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Sort order as '<db-column>' optionally followed by ' ASC' or ' DESC'. Defaults to 'egw_timesheet.ts_id' (oldest first). A table-qualified column such as egw_timesheet.<column> is also accepted. Example: filters[order]=ts_start DESC"
       },
       "filters_search": {
         "name": "filters[search]",

--- a/doc/openapi/tracker.json
+++ b/doc/openapi/tracker.json
@@ -29,11 +29,12 @@
         "tags": ["Tracker"],
         "operationId": "listTickets",
         "summary": "List all tickets the current user has access to",
-        "description": "Returns all tracker tickets accessible to the current user. Supports filtering by status, priority, queue, and assignee. Use 'filters[search]' for full-text search across summary and description.",
+        "description": "Returns tracker tickets accessible to the current user, most recently modified first. Supports filtering by status, priority, queue and assignee, and filters[search] for full-text search across summary and description. To bound the response size, send sync-token= (empty) together with nresults=20; the response then carries a more-results flag and a sync-token for the next chunk.",
         "parameters": [
           { "$ref": "#/components/parameters/props" },
           { "$ref": "#/components/parameters/syncToken" },
           { "$ref": "#/components/parameters/nresults" },
+          { "$ref": "#/components/parameters/filters_order" },
           { "$ref": "#/components/parameters/filters_search" },
           { "$ref": "#/components/parameters/filters_linked" },
           { "$ref": "#/components/parameters/filters_status" },
@@ -43,7 +44,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": ["application/json", "application/pretty+json"]
@@ -129,12 +130,13 @@
         "tags": ["Tracker"],
         "operationId": "listUserTickets",
         "summary": "List all tickets for a given user",
-        "description": "Returns all tracker tickets created by the specified user. Supports the same filters as the current-user endpoint.",
+        "description": "Returns tracker tickets created by the specified user, most recently modified first. Supports the same filters as the current-user endpoint. To bound the response size, send sync-token= (empty) together with nresults=20; the response then carries a more-results flag and a sync-token for the next chunk.",
         "parameters": [
           { "$ref": "#/components/parameters/username" },
           { "$ref": "#/components/parameters/props" },
           { "$ref": "#/components/parameters/syncToken" },
           { "$ref": "#/components/parameters/nresults" },
+          { "$ref": "#/components/parameters/filters_order" },
           { "$ref": "#/components/parameters/filters_search" },
           { "$ref": "#/components/parameters/filters_linked" },
           { "$ref": "#/components/parameters/filters_status" },
@@ -144,7 +146,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": ["application/json", "application/pretty+json"]
@@ -226,7 +228,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": ["application/json", "application/pretty+json"]
@@ -369,7 +371,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": ["application/json", "application/pretty+json"]
@@ -448,7 +450,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": ["application/json", "application/pretty+json"]
@@ -911,7 +913,14 @@
         "in": "query",
         "required": false,
         "schema": { "type": "integer" },
-        "description": "Maximum number of tickets to return."
+        "description": "Limit the number of tickets returned. Only honored together with the sync-token parameter: send sync-token= (empty) plus nresults=N to receive at most N tickets, a \"more-results\": true flag when further tickets exist, and a sync-token to request the next chunk. Sent on its own, nresults has no effect."
+      },
+      "filters_order": {
+        "name": "filters[order]",
+        "in": "query",
+        "required": false,
+        "schema": { "type": "string" },
+        "description": "Sort order as '<db-column>' optionally followed by ' ASC' or ' DESC'. Defaults to 'COALESCE(tr_modified,tr_created) DESC' (newest first). A table-qualified column such as egw_tracker.<column> is also accepted. Example: filters[order]=tr_created DESC"
       },
       "filters_search": {
         "name": "filters[search]",

--- a/infolog/inc/class.infolog_groupdav.inc.php
+++ b/infolog/inc/class.infolog_groupdav.inc.php
@@ -444,7 +444,27 @@ class infolog_groupdav extends Api\CalDAV\Handler
 		// in case of JSON/REST API pass filters to report
 		if (Api\CalDAV::isJSON() && !empty($options['filters']) && is_array($options['filters']))
 		{
-			$filters = $options['filters'] + $filters;    // + to allow overwriting default owner filter (BO ensures ACL!)
+			// CalDAV::jsonIndex() turns filters[start]/filters[end] into a synthetic time-range
+			// element under an integer key. It has to go through _time_range_filter() to become a
+			// SQL fragment: merging it verbatim into the column filter yields "AND Array" and a 500.
+			$json_filters = $options['filters'];
+			$time_ranges = [];
+			foreach($json_filters as $key => $value)
+			{
+				if (!is_string($key))
+				{
+					if (is_array($value) && ($value['name'] ?? null) === 'time-range')
+					{
+						$time_ranges[] = $this->_time_range_filter($value['attrs']);
+					}
+					unset($json_filters[$key]);
+				}
+			}
+			$filters = $json_filters + $filters;    // + to allow overwriting default owner filter (BO ensures ACL!)
+			foreach($time_ranges as $time_range)
+			{
+				$filters[] = $time_range;
+			}
 		}
 		elseif ($options['filters'])
 		{

--- a/timesheet/src/ApiHandler.php
+++ b/timesheet/src/ApiHandler.php
@@ -278,6 +278,18 @@ class ApiHandler extends Api\CalDAV\Handler
 		$cols = [];
 		foreach($filter as $name => $value)
 		{
+			// CalDAV::jsonIndex() appends a synthetic ['name' => 'time-range', ...] element under an
+			// integer key for filters[start]/filters[end]. Timesheet has no time-range support, and
+			// letting it reach the default branch below builds a "ts_0" column from an array, which
+			// surfaces as a 500 echoing the whole egw_timesheet schema back to the client.
+			if (!is_string($name))
+			{
+				if (is_array($value) && ($value['name'] ?? null) === 'time-range')
+				{
+					throw new Api\CalDAV\JsParseException("Timesheet does not support the filters[start] / filters[end] date-range filter");
+				}
+				throw new Api\CalDAV\JsParseException("Invalid filter ".json_encode($value));
+			}
 			switch($name)
 			{
 				case 'search':
@@ -309,6 +321,16 @@ class ApiHandler extends Api\CalDAV\Handler
 						return (int)$val;
 					}, (array)$value);
 					$cols['ts_status'] = count($value) <= 1 ? array_pop($value) : $value;
+					break;
+				case 'order':
+					// passed through to propfind_generator(), which uses it as the SQL ORDER BY:
+					// only allow a (optionally table-qualified) column name plus an optional direction
+					if (!preg_match('/^[a-z0-9_]+(\.[a-z0-9_]+)?( (ASC|DESC))?$/i', (string)$value))
+					{
+						throw new Api\CalDAV\JsParseException("Invalid order filter ".json_encode($value).
+							", expected '<column>' optionally followed by ' ASC' or ' DESC'");
+					}
+					$cols['order'] = $value;
 					break;
 				case 'linked':
 					if (!preg_match('/^([a-z_]+):(\d+)$/i', $filter['linked'], $matches) ||


### PR DESCRIPTION
# Fix REST/JSON collection filters: nresults, date ranges, sort order and a schema disclosure

Found while connecting the `groupdav.php/openapi.json` REST API to an LLM tool-calling client
(Open WebUI). Four independent bugs, all reproducible with plain `curl`. Two return HTTP 500 on
documented parameters, one discloses table schemas, and one makes it impossible to bound a response.

Each commit stands alone and can be dropped independently.

## 1. `nresults` was silently ignored without a `sync-token`

`CalDAV::jsonIndex()` computed the limit but only forwarded it inside the
`if (isset($_GET['sync-token']))` branch, and `addressbook`, `calendar` and `timesheet`
additionally required `$options['root']['name'] === 'sync-collection'`. A REST client therefore had
no way to bound a collection listing and always received the entire collection serialized as
JsContact / JsEvent / JsTask objects.

```
GET /groupdav.php/addressbook/?nresults=5      before: 10 entries    after: 5 entries
GET /groupdav.php/addressbook/?sync-token=&nresults=5     unchanged: 5 + more-results
```

Both gates are relaxed. `sync-collection` semantics (`more-results` plus a new `sync-token`) are
unchanged, and its forced ascending order still applies.

## 2. `addressbook` and `timesheet` defaulted to oldest-first

Defaults were `egw_addressbook.contact_id` and `egw_timesheet.ts_id`, both ascending. Combined with
(1), a limited request returns the N *oldest* entries — a plausible-looking wrong answer rather than
a visible failure. Now `contact_modified DESC` / `ts_modified DESC`. `infolog` already used
`info_datemodified DESC`; `calendar` has no ordering support.

Shipped in the same commit as (1) deliberately: a row cap without a sensible order is worse than no
cap at all.

## 3. `filters[start]` / `filters[end]` returned HTTP 500 on infolog and timesheet

`CalDAV::jsonIndex()` converts these into a synthetic
`['name' => 'time-range', 'attrs' => [...]]` element under an integer key. The JSON branch of
`infolog_groupdav::_report_filters()` merged `$options['filters']` verbatim into the column filter,
so the array became a column:

```
GET /groupdav.php/<user>/infolog/?filters[start]=2026-07-01&filters[end]=2026-08-01
-> 500  Invalid SQL: ... AND Array ...  Unknown column 'Array' in 'WHERE'
```

It now goes through the existing `_time_range_filter()` helper, as the CalDAV/XML branch already
did. Verified against real rows: a June window matches the tasks due in June, a July window matches
none, and a narrow window discriminates correctly.

Timesheet genuinely has no time-range support, so there the same element now raises a
`JsParseException` (422) with an explanatory message instead of building a bogus `ts_0` column.
`doc/openapi/timesheet.json` documents this.

## 4. Unknown filter names disclosed the full table schema

`Db::column_data_implode()` embedded `print_r($column_definitions)` *and* the supplied values in the
`InvalidSql` exception message, and `CalDAV::exception_handler()` echoes that message to the client:

```
GET /groupdav.php/<user>/timesheet/?filters[start]=2026-07-01
-> 500, 3832 bytes containing every column of egw_timesheet with types and precisions
```

The arrays are still written to `error_log()` for debugging; only the exception message is now a
single line. The same request returns 76 bytes.

> This is the only change in core framework code. It alters the exception *message* only — no
> control flow — and fixes the disclosure once for every app rather than per handler.

## Also included

- **`calendar` silently ignored `filters[search]` and `filters[linked]`.**
  `calendar_groupdav::_report_filters()` had no `Api\CalDAV::isJSON()` branch, unlike the other three
  handlers, so REST filters (a plain `name => value` array, not CalDAV XML elements) all fell through
  to `unknown filter --> ignored`, while `doc/openapi/calendar.json` advertised both. Added
  `jsonReportFilters()`.
  `filters[linked]` uses `query['egw_cal.cal_id']` rather than `sql_filter`, because
  `calendar_bo::search()` deliberately overwrites `$params['sql_filter']` from its own second
  argument. `calendar_bo::search()` accepts only one "query", so a free-text `filters[search]` cannot
  be combined with `filters[linked]`; that combination now reports a clear error rather than dropping
  one silently.

- **`filters[order]` was unreachable on `timesheet`.** Its column mapper rewrote `order` to
  `ts_order`, producing bug (4). Now passed through, restricted to an optionally table-qualified
  column plus an optional direction. `so_sql::search()` already sanitises `order_by`, so this only
  converts a silently mangled sort into an explicit 422.

- **`doc/openapi/*.json` corrections.** These descriptions are what an LLM client actually sees, so
  wrong ones directly produce wrong requests:
  - `filters[start]` / `filters[end]` declared `"type": "datetime"`, which is **not a valid JSON
    Schema type**. Clients that map OpenAPI parameters onto function schemas pass it through
    verbatim, so the parameter arrives unusable and date filters are never sent. Now
    `"type": "string"` with `"format": "date"`.
  - `nresults` was described as *"Limit number of responses (only for sync-collection)"*, actively
    discouraging clients from sending it.
  - `filters[order]` is now documented for the four apps whose handlers read it (not `calendar`).
  - The `filters[end]` example read `filters[start]=2026-02-01`.
  - `Accept` is no longer `required: true` — it is an `in: header` parameter, and tool executors that
    forward only `path` and `query` parameters force a value that is then discarded. It remains in
    the spec as optional documentation.

