### PR TITLE
Et2DateRange: don't retry a value set on a disconnected element via u…

### DIFF
--- a/api/js/etemplate/Et2Date/Et2DateRange.ts
+++ b/api/js/etemplate/Et2Date/Et2DateRange.ts
@@ -49,9 +49,31 @@ export class Et2DateRange extends Et2InputWidget(LitElement)
 		}
 	}
 
+	/**
+	 * Value set while not connected, applied once the element connects.
+	 * The setter must not wait on updateComplete while disconnected: on an element
+	 * that never (re-)connects updateComplete is already resolved, so the retry
+	 * re-enters the setter in an endless microtask loop and freezes the tab.
+	 */
+	private _disconnectedValue : { to : string, from : string } | string;
+
 	constructor()
 	{
 		super();
+	}
+
+	connectedCallback()
+	{
+		super.connectedCallback();
+		if(typeof this._disconnectedValue !== "undefined")
+		{
+			const value = this._disconnectedValue;
+			this._disconnectedValue = undefined;
+			this.updateComplete.then(() =>
+			{
+				this.value = value;
+			});
+		}
 	}
 
 	_handleChange(event)
@@ -190,10 +212,7 @@ export class Et2DateRange extends Et2InputWidget(LitElement)
 	{
 		if(!this.isConnected)
 		{
-			this.updateComplete.then(() =>
-			{
-				this.value = new_value;
-			});
+			this._disconnectedValue = new_value;
 			return;
 		}
 		if(this.relative)


### PR DESCRIPTION
## Bug

`Et2DateRange`'s value setter retries itself via `updateComplete` while the element is not connected:

```ts
public set value(new_value : {to:string,from:string}|string)
{
	if(!this.isConnected)
	{
		this.updateComplete.then(() => { this.value = new_value; });
		return;
	}
```

This is fine for an element that has not been connected *yet*. But for an element that was **removed from the DOM and never reconnects** (e.g. its etemplate was cleared/reloaded while a value set was in flight), `updateComplete` is already resolved, so every retry immediately schedules another microtask that re-enters the setter. The result is an endless microtask loop: the main thread never yields and the whole browser tab hard-freezes - no stack overflow, no console output, DevTools cannot attach. Sampling the frozen renderer showed 850,000+ `Promise.then` calls from this one setter.

## Reproduce

```js
const range = document.createElement('et2-date-range');
document.body.append(range);
await range.updateComplete;
range.remove();
range.value = {from: '2026-01-01T00:00:00Z', to: null};  // tab freezes
```

In practice we hit it through a nextmatch with a date-range filter header being torn down and reloaded (`Et2AppBox.load()` on a box that already had content): a late value set on the discarded filter widget froze the tab reproducibly.

## Fix

Stash the value while disconnected and apply it in `connectedCallback()` - same behaviour for the "set before first connection" case the retry was written for, without the freeze. Running this patch locally without issues.

The similar-looking retries in `Et2Date` / `Et2DateTimeOnly` only assign to `this._inputNode.value` and cannot re-enter their own setter, so they are not affected.