### PR TITLE
Et2Iframe/et2_iframe: clear a leftover srcdoc attribute in set_src()

### DIFF
--- a/api/js/etemplate/Et2Iframe/Et2Iframe.ts
+++ b/api/js/etemplate/Et2Iframe/Et2Iframe.ts
@@ -85,8 +85,10 @@ export class Et2Iframe extends Et2Widget(LitElement)
 	{
 		if(_value.trim() != "")
 		{
+			// a leftover srcdoc attribute overrides src and suppresses the load event
 			if(_value.trim() == 'about:blank')
 			{
+				this.__getIframeNode().removeAttribute('srcdoc');
 				this.__getIframeNode().src = _value;
 			}
 			else
@@ -95,6 +97,7 @@ export class Et2Iframe extends Et2Widget(LitElement)
 				let loader = jQuery('<div class="et2_iframe loading"/>');
 				this.__getIframeNode().before(loader);
 				window.setTimeout(function() {
+					this.__getIframeNode().removeAttribute('srcdoc');
 					this.__getIframeNode().src = _value;
 					this.__getIframeNode().addEventListener('load',function() {
 						loader.remove();

--- a/api/js/etemplate/et2_widget_iframe.ts
+++ b/api/js/etemplate/et2_widget_iframe.ts
@@ -151,8 +151,10 @@ export class et2_iframe extends et2_valueWidget
 	{
 		if(_value.trim() != "")
 		{
+			// a leftover srcdoc attribute overrides src and suppresses the load event
 			if(_value.trim() == 'about:blank')
 			{
+				this.htmlNode.removeAttr("srcdoc");
 				this.htmlNode.attr("src", _value);
 			}
 			else
@@ -162,6 +164,7 @@ export class et2_iframe extends et2_valueWidget
 				this.htmlNode
 					.before(loader);
 				window.setTimeout(jQuery.proxy(function() {
+					this.htmlNode.removeAttr("srcdoc");
 					this.htmlNode.attr("src", _value)
 						.one('load',function() {
 							loader.remove();


### PR DESCRIPTION
## Bug

Per the HTML spec, an iframe's `srcdoc` attribute **takes precedence over `src`**. Both iframe widgets set `src` in `set_src()` without removing a leftover `srcdoc`, so an iframe that previously displayed inline content via `srcdoc` never navigates when `src` is set - and never fires a `load` event.

## How it shows up

Mail's preview hits this since the JMAP fast path was added. `MailApp.loadMessageBody()`:

- renders normal messages by assigning `iframe.srcdoc = fast.html` (fast path), and
- falls back to `iframeWidget.set_src(egw.link('/index.php', {menuaction: 'mail.mail_ui.loadEmailBody', ...}))` for special messages (meeting invites, S/MIME, winmail.dat, PGP/MIME) with a `{once: true}` `load` listener.

Sequence to reproduce:

1. Preview any normal mail (fast path -> iframe gets `srcdoc`).
2. Preview a meeting-invite mail (fallback path -> `set_src()`).
3. The leftover `srcdoc` keeps overriding `src`: the iframe never navigates, the `load` listener never fires, `onLoad` never runs and the preview shows the loading spinner forever.

## Fix

Remove the `srcdoc` attribute before setting `src` in both places:

- `et2_widget_iframe.ts` (the legacy widget - `mail.index`'s `messageIFRAME` uses this one), and
- `Et2Iframe.ts` (the web component, same latent problem for anything mixing `srcdoc` and `src`).

No behaviour change for iframes that never used `srcdoc` - removing an absent attribute is a no-op. Running this fix locally without issues.