### PR TITLE
Et2Number: render unset values empty instead of the literal "NaN"

### DIFF
--- a/api/js/etemplate/Et2Textbox/Et2Number.ts
+++ b/api/js/etemplate/Et2Textbox/Et2Number.ts
@@ -231,6 +231,13 @@ export class Et2Number extends Et2Textbox
 	set value(val)
 	{
 		const old = this.value;
+		// An unset value must render empty: parseFloat(null) is NaN and the input
+		// would show the literal "NaN", which then fails save validation
+		if(val === null || typeof val === "undefined" || (typeof val === "number" && isNaN(val)))
+		{
+			val = "";
+		}
+		const raw = val;
 		if("" + val !== "")
 		{
 			// Remove separator so parseFloat works
@@ -266,7 +273,8 @@ export class Et2Number extends Et2Textbox
 		}
 		if(val == "" || isNaN(val))
 		{
-			super.value = val;
+			// Keep the raw text (never the parsed NaN) so the validator can flag it
+			super.value = "" + raw;
 			this.requestUpdate("value", old);
 			return;
 		}


### PR DESCRIPTION
## Bug

An empty value reaches `Et2Number`'s value setter as `null` - for example the customfields widget passes `null` for every float custom field without a stored value (`et2_extension_customfields.ts` `set_value()`). The setter runs `parseFloat(null)` -> `NaN`, and the guard branch then assigns that **parsed NaN** into `super.value`, so the input renders the literal text **"NaN"**.

Saving afterwards fails the pattern validation with e.g. (German/Greek/... localized):

> Το 'NaN' δεν ταιριάζει με το απαιτούμενο μοτίβο ('/^-?[0-9]*[,.]?[0-9]*$/')

We hit this in a list preview that fills a customfields widget for entries whose visible float custom fields have no stored value, and equally in an edit dialog rendering the same fields - any `et2-number` that gets its value set to `null`/`undefined` shows "NaN" and then blocks the save.

The same applies to unparsable strings: `parseFloat("abc")` is `NaN` and the input silently turned the user's text into "NaN", hiding what was actually typed.

## Fix

In the value setter:

- normalize `null` / `undefined` / `NaN` numbers to `""` before parsing, so unset values render empty, and
- in the unparsable guard keep the **raw** text instead of the parsed `NaN`, so validation flags what was actually entered.

No change for real numeric values. Verified against the originally failing entries: empty float custom fields render empty, saving passes, and no "NaN" is written anywhere.