### PR TITLE
customfields: leave never-set numeric fields unset instead of NaN, clear reused widgets

### DIFF
--- a/api/js/etemplate/Et2Customfields/Et2CustomfieldWidgetMapper.ts
+++ b/api/js/etemplate/Et2Customfields/Et2CustomfieldWidgetMapper.ts
@@ -152,10 +152,14 @@ export function mapCustomfieldToWidget(
 			break;
 
 		case "date":
+			// the container renders the label column itself - a label attr would show twice
+			// (filters re-set it after the switch, they have no label column)
+			delete attrs.label;
 			attrs.data_format = field.values?.format || "Y-m-d";
 			break;
 
 		case "date-time":
+			delete attrs.label;
 			attrs.data_format = field.values?.format || "Y-m-d H:i:s";
 			break;
 

--- a/api/js/etemplate/Et2Customfields/Et2Customfields.ts
+++ b/api/js/etemplate/Et2Customfields/Et2Customfields.ts
@@ -31,13 +31,18 @@ export class Et2Customfields extends Et2CustomfieldsBase
 
 				.customfields {
 					display: grid;
-					grid-template-columns: max-content minmax(0, 1fr);
+					/* cap the label column: max-content lets a long label claim the whole
+					   width and squeeze the value to nothing in narrow panes - beyond the
+					   cap the label wraps instead */
+					grid-template-columns: fit-content(45%) minmax(0, 1fr);
 					gap: var(--sl-spacing-2x-small, 0.25rem) var(--sl-spacing-small, 0.75rem);
 					align-items: start;
 				}
 
 				.customfields__label {
 					padding-top: var(--sl-spacing-2x-small, 0.25rem);
+					min-width: 0;
+					overflow-wrap: break-word;
 				}
 
 				.customfields__field {
@@ -54,6 +59,80 @@ export class Et2Customfields extends Et2CustomfieldsBase
 	protected createRenderRoot()
 	{
 		return this;
+	}
+
+		private _dirtySnapshot : string | null = null;
+
+	/**
+	 * Collect '#name' => value pairs from the rendered field widgets.
+	 *
+	 * Only the legacy DEFAULT_ID instance ('custom_fields') answers with the collected
+	 * object - matching et2_customfields_list.getValue() - so an id-less instance in an
+	 * edit dialog returns null and etemplate2.getValues() leaves submission to the
+	 * individual '#name' child widgets.
+	 */
+	getValue() : Record<string, any> | null
+	{
+		return this.id === "custom_fields" ? this._collectValues() : null;
+	}
+
+	set_value(value : Record<string, any> | null)
+	{
+		this.value = value || {};
+	}
+
+	isDirty() : boolean
+	{
+		// no snapshot taken yet means nothing to compare against, not "everything changed"
+		return this._dirtySnapshot !== null && this._dirtySnapshot !== JSON.stringify(this._collectValues());
+	}
+
+	resetDirty()
+	{
+		// set_visible()/set_value() only queue a Lit re-render: snapshot after it settles,
+		// or the snapshot describes the previous entry's fields and every row click looks
+		// like unsaved changes. null in the meantime means "not dirty" to isDirty().
+		this._dirtySnapshot = null;
+		const token = ++this._dirtySnapshotToken;
+		this._renderSettled().then(() =>
+		{
+			if(token === this._dirtySnapshotToken)
+			{
+				this._dirtySnapshot = JSON.stringify(this._collectValues());
+			}
+		});
+	}
+
+	private _dirtySnapshotToken = 0;
+
+	private async _renderSettled()
+	{
+		await this.updateComplete;
+		await Promise.all(Array.from(this.querySelectorAll("[data-field] > *"))
+			.map((widget : any) => widget.updateComplete)
+			.filter(Boolean));
+	}
+
+	isValid() : boolean
+	{
+		return true;
+	}
+
+	private _collectValues() : Record<string, any>
+	{
+		const result : Record<string, any> = {};
+		const widgetValue = (widget : any) => (typeof widget?.getValue === "function" ? widget.getValue() : widget?.value) ?? "";
+		for(const wrapper of Array.from(this.querySelectorAll("[data-field]")))
+		{
+			const fieldName = wrapper.getAttribute("data-field");
+			const widget = wrapper.querySelector(":scope > :not(label)") as any;
+			if(!fieldName || !widget)
+			{
+				continue;
+			}
+			result[CUSTOMFIELD_PREFIX + fieldName] = widgetValue(widget);
+		}
+		return result;
 	}
 
 	private _fieldValue(fieldName : string)
@@ -91,13 +170,18 @@ export class Et2Customfields extends Et2CustomfieldsBase
 
                 et2-customfields .customfields {
                     display: grid;
-                    grid-template-columns: max-content minmax(0, 1fr);
+                    /* cap the label column: max-content lets a long label claim the whole
+                       width and squeeze the value to nothing in narrow panes - beyond the
+                       cap the label wraps instead */
+                    grid-template-columns: fit-content(45%) minmax(0, 1fr);
                     gap: var(--sl-spacing-2x-small, 0.25rem) var(--sl-spacing-small, 0.75rem);
                     align-items: start;
                 }
 
                 et2-customfields .customfields__label {
                     padding-top: var(--sl-spacing-2x-small, 0.25rem);
+                    min-width: 0;
+                    overflow-wrap: break-word;
                 }
 
                 et2-customfields .customfields__field {

--- a/api/js/etemplate/et2_extension_customfields.ts
+++ b/api/js/etemplate/et2_extension_customfields.ts
@@ -637,6 +637,24 @@ export class et2_customfields_list extends et2_valueWidget implements et2_IDetac
 
 			switch(this.options.customfields[field_name].type)
 			{
+				case 'float':
+				case 'int':
+				case 'number':	// _setup_float / _setup_int rewrite field.type to "number" on row creation
+					// et2-number renders null via parseFloat as the literal "NaN".  Leave a
+					// never-set field alone instead of turning "not yet set" into "set as
+					// empty", but a reused widget still showing the previous entry's number
+					// (preview / CRM-view row clicks) must be cleared
+					if(value === null)
+					{
+						const widget : any = this.widgets[field_name];
+						const current = typeof widget.getValue === "function" ? widget.getValue() : widget.value;
+						if(current === "" || current === null || typeof current === "undefined")
+						{
+							continue;
+						}
+						value = "";
+					}
+					break;
 				case 'date':
 					// Date custom fields are always in Y-m-d, which seldom matches user's preference
 					// which fails when sent to date widget.  This is only used for nm rows, when possible


### PR DESCRIPTION
## Problem

Float and integer custom fields without a stored value render the literal text **"NaN"** in edit forms, and saving the entry then fails the `/^-?[0-9]*[,.]?[0-9]*$/` pattern validation — the record cannot be saved at all while such a field is visible.

## Cause

`et2_customfields_list.set_value()` coerces missing (and falsy) stored values to `null` before pushing them into the per-field child widgets:

```ts
let value = _value[this.options.prefix + field_name] ? _value[this.options.prefix + field_name] : null;
```

For float/int custom fields the child is an `et2-number`, whose value setter passes the value through `parseFloat`. `"" + null` is `"null"`, so it slips past the empty-value guard, and `parseFloat(null)` parses the string `"null"` → `NaN`. With `precision` set, `NaN.toFixed(precision)` produces the string `"NaN"`, which is written into the input.

## Fix

Per review feedback: `null` is no longer pushed into the child widget at all — a pristine widget is left completely untouched, so "not yet set" stays unset instead of becoming "set as empty".

A plain skip is not quite enough, though: preview / CRM-style views reuse one widget instance across records via `set_value()`, and skipping there would leave the previous record's number displayed on a record where the field is unset. So `null` is skipped only while the widget currently shows nothing, and clears it otherwise.

The switch matches `"number"` as well as `"float"`/`"int"`, because `_setup_float`/`_setup_int` rewrite `field.type` on the shared field object during row creation — `"number"` is the type `set_value()` actually sees at runtime.

The newer `Et2Customfields` web component is not affected: its `_fieldValue()` already maps missing/null values to `""` via nullish coalescing.

## Relation to the previous approach (#268)

#268 fixed the same symptom inside `Et2Number` itself, by normalizing `null`/`undefined`/`NaN` in its value setter. As @nathangray pointed out there, `null` has the special meaning "not set" for form submission (null values are omitted by `etemplate2.getValues()`), so changing how the shared widget handles `null` is riskier than it looks. This PR fixes the producer instead, so `null` never reaches the widget, and leaves `Et2Number` untouched. I'd suggest this one replaces #268.

## Second commit: Et2Customfields legacy input API + label layout

Rounds out `Et2Customfields` as a drop-in for the legacy widget and fixes two layout problems that surface in narrow panes:

**Legacy input API.** App code that addresses the customfields widget as a single input (the way `et2_customfields_list` allowed) needs:
- `set_value()`
- `getValue()` — answers with the collected `#name => value` object only for the legacy `DEFAULT_ID` `custom_fields` and `null` otherwise, matching the legacy widget, so etemplate2 submission stays with the individual `#name` child widgets
- snapshot-based `isDirty()`/`resetDirty()` — `resetDirty()` snapshots only after the queued Lit re-render (and the child widgets) settle; a synchronous snapshot describes the previously shown fields and makes every `set_value()` look like unsaved changes

**Layout.** The label column was `max-content`, so one long label squeezes every value input to a sliver in a narrow pane; it is now `fit-content(45%)`, making long labels wrap instead. And `date`/`date-time` field widgets kept their `label` attr, so they rendered the label a second time above the input — the container already renders the label column, the attr is now dropped (filters re-set it after the switch, they have no label column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFMF3JZxodnWwbNqurKN7s