### PR TITLE
Et2Nextmatch: stop CustomfieldsHeader's endless update loop when all customfield columns are hidden

### DIFF
--- a/api/js/etemplate/Et2Nextmatch/Headers/CustomfieldsHeader.ts
+++ b/api/js/etemplate/Et2Nextmatch/Headers/CustomfieldsHeader.ts
@@ -126,7 +126,12 @@ export class Et2CustomfieldsHeader extends Et2Widget(LitElement)
 		}
 		// Some templates populate global customfield modifications after initial attribute transform.
 		// Keep one-way hydration from modifications so initial render has field list without user interaction.
-		if(!this.customfields || !Object.keys(this.customfields).length || !this.fields || !Object.keys(this.fields).length)
+		// An explicit fields map is a sparse allow-list: empty legitimately means "all hidden", so only
+		// missing metadata (or a non-explicit empty fields map) warrants a re-sync - treating the explicit
+		// empty map as missing re-entered the sync on every update and hard-froze the tab (endless
+		// performUpdate loop when custom fields are defined but every customfield column is hidden).
+		if(!this.customfields || !Object.keys(this.customfields).length ||
+			(!this._hasExplicitFields && (!this.fields || !Object.keys(this.fields).length)))
 		{
 			this._syncCustomfieldsFromModifications();
 		}
@@ -221,7 +226,13 @@ export class Et2CustomfieldsHeader extends Et2Widget(LitElement)
 		if(changed)
 		{
 			this.customfields = attrs.customfields || {};
-			this.fields = preserveVisibility ? {...previousFields} : (attrs.fields || {});
+			// When visibility is explicit the merged fields are discarded - do NOT assign a fresh
+			// clone of the unchanged map, or Lit sees a "changed" property on every sync and the
+			// update/updated cycle re-enters itself forever
+			if(!preserveVisibility)
+			{
+				this.fields = attrs.fields || {};
+			}
 			this._hasExplicitFields = preserveVisibility;
 			this.exclude = attrs.exclude || this.exclude;
 			this.typeFilter = typeof attrs.typeFilter === "undefined" ? this.typeFilter : attrs.typeFilter;


### PR DESCRIPTION
**Symptom:** the browser tab hard-freezes (renderer unresponsive, must be killed) as soon as anything re-applies column preferences on a nextmatch whose app has custom fields defined while the user has every customfield column hidden — e.g. applying a filter. There is no stack overflow and no console output, which makes it very hard to diagnose: profiling probes on promises, timers, rAF and events all come back clean; only wrapping Lit's `performUpdate` reveals the loop.

**Cause:** the datagrid's column-preferences pass hands `Et2CustomfieldsHeader` an explicit empty `fields` map ("all hidden"). `updated()` treats the empty map as "not yet hydrated" and calls `_syncCustomfieldsFromModifications()`, which reports `changed` and reassigns `this.fields = {...previousFields}` — a fresh but content-identical object. Lit's default `hasChanged` is `!==`, so every update schedules the next one, forever.

**Fix:**
- don't reassign `fields` when explicit visibility is preserved anyway (no fresh clone → no phantom property change),
- treat an explicit empty allow-list as a legitimate state, not as missing data needing re-sync.

Verified live against a production instance exhibiting the freeze (patching the deployed class the same way stops the loop; the filter applies normally). `Et2Nextmatch` test suite passes (149/149), including `CustomfieldsHeader.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)