### PR TITLE
 egw_action: don't let a throwing enabled callback abort the whole context menu

### DIFF
--- a/api/js/egw_action/EgwActionObject.ts
+++ b/api/js/egw_action/EgwActionObject.ts
@@ -993,6 +993,22 @@ export class EgwActionObject {
         const actionLinks:any = {};
         const testedSelected = [];
 
+        // An app's enabled callback may assume its object is a data row - eg. filemanager's
+        // isEditable() reads egw.dataGetUIDdata(id).data - and throws for an object that is
+        // not one, like the datagrid's empty-list placeholder (which offers mkdir/paste/share).
+        // A single throwing callback used to abort the whole popup, so no context menu opened
+        // at all.  Treat it as "not enabled" and keep building the rest of the menu.
+        const isEnabledFor = function (actionObj, obj) {
+            try {
+                return actionObj.enabled.exec(actionObj, _objs, obj);
+            }
+            catch (e) {
+                console.error("egw_action: enabled callback of action '" + actionObj.id +
+                    "' threw, treating it as disabled", e);
+                return false;
+            }
+        };
+
         const test = function (olink,obj) {
             // Test whether the action type is of the given implementation type
             if (olink.actionObj.type == _actionType) {
@@ -1007,7 +1023,7 @@ export class EgwActionObject {
 
                 // Accumulate the action link properties
                 const llink = actionLinks[olink.actionId];
-                llink.enabled = llink.enabled && olink.actionObj.enabled.exec(olink.actionObj, _objs, obj) && olink.enabled && olink.visible;
+                llink.enabled = llink.enabled && isEnabledFor(olink.actionObj, obj) && olink.enabled && olink.visible;
                 llink.visible = (llink.visible || olink.visible);
                 llink.cnt++;
 

--- a/filemanager/js/filemanager.ts
+++ b/filemanager/js/filemanager.ts
@@ -1743,10 +1743,10 @@ export class filemanagerAPP extends EgwApp
 			return false;
 		}
 		let data = egw.dataGetUIDdata(_senders[0].id);
-		let readonly = (data?.data.class || '').split(/ +/).indexOf('noEdit') >= 0;
+		let readonly = (data?.data?.class || '').split(/ +/).indexOf('noEdit') >= 0;
 
 		// symlinks dont have mime 'http/unix-directory', but server marks all directories with class 'isDir'
-		return (!_senders[0].id || data.data.is_dir && !readonly);
+		return (!_senders[0].id || data?.data?.is_dir && !readonly);
 	}
 
 	hiddenUploadComplete(event)
@@ -1847,16 +1847,19 @@ export class filemanagerAPP extends EgwApp
 	isEditable(_egwAction, _senders) : boolean
 	{
 		if (_senders.length>1) return false;
-		let data = egw.dataGetUIDdata(_senders[0].id);
+		// no row data: the sender is not a file row (eg. the datagrid's empty-list
+		// placeholder, which still offers mkdir/paste/share) - nothing to edit
+		let data = egw.dataGetUIDdata(_senders[0]?.id);
+		if (!data?.data?.mime) return false;
 		let fe = egw.file_editor_prefered_mimes(data.data.mime);
-		return data?.data?.mime && fe?.mime && typeof fe.mime[data.data.mime] !== "undefined";
+		return !!(fe?.mime && typeof fe.mime[data.data.mime] !== "undefined");
 	}
 
 	checkInvoice(_egwAction, _senders) : boolean
 	{
 		if (_senders.length>1) return false;
-		let data = egw.dataGetUIDdata(_senders[0].id);
-		return data.data?.mime && ['application/pdf', 'text/xml', 'application/xml'].includes(data.data.mime);
+		let data = egw.dataGetUIDdata(_senders[0]?.id);
+		return !!(data?.data?.mime && ['application/pdf', 'text/xml', 'application/xml'].includes(data.data.mime));
 	}
 
 	/**


### PR DESCRIPTION
## What happens today

`EgwActionObject._getLinks()` evaluates the `enabled` callback of **every** action linked to the object a popup is being built for:

```js
llink.enabled = llink.enabled && olink.actionObj.enabled.exec(olink.actionObj, _objs, obj) && olink.enabled && olink.visible;
```

Those callbacks are app code. If one of them throws, the exception propagates out of the whole popup build — **no context menu opens at all**, and the only trace is a `TypeError` in the console. Every other action in that menu is lost along with the broken one, and a right-click that silently does nothing gives the user no hint where to look.

## Why callbacks throw

They routinely assume their object is a data row. `filemanager`'s `isEditable()`:

```js
let data = egw.dataGetUIDdata(_senders[0].id);
let fe = egw.file_editor_prefered_mimes(data.data.mime);   // data is undefined -> throws
```

For any action object that has no row in the data cache this is `Cannot read properties of undefined (reading 'data')`.

This is a known situation, just handled ad-hoc: `filemanager.hidden_upload_enabled()` already opens with

```js
if(_senders[0].id == 'nm') { return false; }
```

i.e. one callback was taught about a non-row sender, while `isEditable()` and `checkInvoice()` next to it were not.

## Concrete failure

An embedded filemanager list showing no entries, where the popup target is the list's empty placeholder object rather than a file row. `collabora` links `openasnew`, `convert_to` and the writable-link share children to `app.filemanager.isEditable` (`collabora/src/Ui.php:118,146`), so assembling that menu threw — and the user got **no menu whatsoever**, including *Create directory*, *Paste* and *Share*, which are the only way to put anything into an empty directory. Pasting a file from one entry into another was impossible for exactly the case where the target directory is still empty.

Verified with a debugger on the running instance: catching the throw around the popup build makes the correct menu appear immediately (*Create directory* / *Paste ▸* / *Share ▸*), and *Paste ▸ Copy into folder* then copies the file as expected.

## The change

**`api/js/egw_action/EgwActionObject.ts`** — run each `enabled` callback through a guard; a throwing one is treated as *not enabled* and logged with the id of the offending action:

```js
const isEnabledFor = function (actionObj, obj) {
    try {
        return actionObj.enabled.exec(actionObj, _objs, obj);
    }
    catch (e) {
        console.error("egw_action: enabled callback of action '" + actionObj.id +
            "' threw, treating it as disabled", e);
        return false;
    }
};
```

An action whose enablement cannot be determined disables *itself* instead of taking the menu down. No behaviour change for callbacks that do not throw — the failure is still visible in the console, now with the action id attached.

**`filemanager/js/filemanager.ts`** — stop `isEditable()`, `checkInvoice()` and `hidden_upload_enabled()` from assuming `dataGetUIDdata()` found a row, so they do not throw in the first place. `isEditable()` and `checkInvoice()` also return a real boolean rather than the truthy mime string, matching their `: boolean` signature.

## Risk

Two files, +26/−7, no API change. The api-side guard only alters what happens on a code path that previously ended in an uncaught exception; the filemanager guards only add a "no row data → false" branch to three predicates that already returned false for anything without a usable mime.
