### PR TITLE
Et2Datagrid - keep the column headers aligned with the rows below

### DIFF
--- a/api/js/etemplate/Et2Datagrid/Et2Datagrid.styles.ts
+++ b/api/js/etemplate/Et2Datagrid/Et2Datagrid.styles.ts
@@ -130,6 +130,14 @@ export default css`
 		padding: var(--sl-spacing-2x-small) var(--sl-spacing-small);
 		border-right: var(--sl-panel-border-width) solid var(--sl-color-neutral-400);
 		box-sizing: border-box;
+		/*
+		 * Header and rows are separate grids that only line up because both resolve the same
+		 * --column-sizes. An "Nfr" track is minmax(auto, Nfr), so a grid item that can not shrink
+		 * below its min-content raises its own track - a long header label would widen its column
+		 * in the header only, and every following column would be off by that much. The row cells
+		 * already opt out of that (see "tbody td, tbody th" below), the header has to as well.
+		 */
+		min-width: 0;
 
 		/* Inner div lets us have clear space on the right edge of the column header */
 

--- a/api/js/etemplate/Et2Datagrid/Et2Datagrid.ts
+++ b/api/js/etemplate/Et2Datagrid/Et2Datagrid.ts
@@ -316,6 +316,8 @@ export class Et2Datagrid extends Et2Widget(LitElement)
 	private _embeddedVirtualizedHeightSyncPassesRemaining : number = 0;
 	private _embeddedParentScrollOffsetTop : number | null = null;
 	private _embeddedChildGridResizeObserver : ResizeObserver | null = null;
+	private _headerColumnResizeObserver : ResizeObserver | null = null;
+	private _observedHeaderColumns : HTMLElement[] = [];
 	private _embeddedChildGridObserverSyncFrame : number | null = null;
 	private _remeasuredEmbeddedChildGridsThisFrame : WeakSet<Et2Datagrid> = new WeakSet();
 	private _embeddedChildScrollSyncFrame : number | null = null;
@@ -814,6 +816,9 @@ export class Et2Datagrid extends Et2Widget(LitElement)
 		this._embeddedVirtualizedHeightSyncPassesRemaining = 0;
 		this._embeddedChildGridResizeObserver?.disconnect();
 		this._embeddedChildGridResizeObserver = null;
+		this._headerColumnResizeObserver?.disconnect();
+		this._headerColumnResizeObserver = null;
+		this._observedHeaderColumns = [];
 		if(this._embeddedChildGridObserverSyncFrame !== null)
 		{
 			cancelAnimationFrame(this._embeddedChildGridObserverSyncFrame);
@@ -1145,6 +1150,7 @@ export class Et2Datagrid extends Et2Widget(LitElement)
 			this._applyColumnVisibilityToRenderedRows();
 			this._postRenderStructureSyncNeeded = false;
 		}
+		this._syncHeaderColumnObserver();
 		this._syncDomEventTargets();
 		if(changedProperties.has("rows") || changedProperties.has("expansionConfig"))
 		{
@@ -4835,10 +4841,95 @@ export class Et2Datagrid extends Et2Widget(LitElement)
 	 */
 	private _ensureTableColSizes()
 	{
-		const visibleColumns = this._visibleColumns();
-		if(this._body)
+		if(!this._body)
 		{
-			this._body.style["--column-sizes"] = this._columnWidths(visibleColumns);
+			return;
+		}
+		if(this.inheritColumnSizes)
+		{
+			// embedded child grids inherit the parent grid's tracks through the host
+			this._body.style.removeProperty("--column-sizes");
+			return;
+		}
+		// custom properties need setProperty(), plain indexed assignment is silently ignored
+		this._body.style.setProperty("--column-sizes", this._rowColumnSizes(this._visibleColumns()));
+	}
+
+	/**
+	 * Track list for the body rows: the header's track list, with content-sized
+	 * "auto" tracks (columns without a configured width) pinned to the header's
+	 * resolved pixel width.
+	 *
+	 * Header and rows are separate grids that only line up because both resolve
+	 * the same track list. An auto track sizes to each grid's own content - the
+	 * header to its label, the rows to their widest value - and the leftover
+	 * space then distributes differently into every fr track, shifting all
+	 * column boundaries between header and rows.
+	 */
+	private _rowColumnSizes(visibleColumns : Et2DatagridColumn[]) : string
+	{
+		const sizes = this._columnWidths(visibleColumns);
+		if(!/\bauto\b/.test(sizes))
+		{
+			return sizes;
+		}
+		const header = this.shadowRoot?.querySelector(".dg-header") as HTMLElement;
+		if(!header)
+		{
+			return sizes;
+		}
+		const resolved = getComputedStyle(header).gridTemplateColumns.trim().split(/\s+/);
+		const tracks = this._splitTrackList(sizes);
+		// the resolved header list leads with the meta column track
+		if(resolved.length !== tracks.length + 1)
+		{
+			return sizes;
+		}
+		return tracks.map((track, index) => track === "auto" ? resolved[index + 1] : track).join(" ");
+	}
+
+	/**
+	 * Split a grid-template-columns track list on top-level spaces only -
+	 * "minmax(30px, 1fr)" is one track.
+	 */
+	private _splitTrackList(sizes : string) : string[]
+	{
+		return sizes.match(/(?:[^\s()]+|\([^)]*\))+/g) || [];
+	}
+
+	/**
+	 * Re-pin the rows' auto tracks whenever header column boxes change.
+	 *
+	 * The header widgets render asynchronously, so the auto track measured
+	 * during updated() is the width of a still-empty header. The observer
+	 * fires once the content (and any later container resize) settles.
+	 */
+	private _syncHeaderColumnObserver()
+	{
+		const needed = !this.inheritColumnSizes &&
+			/\bauto\b/.test(this._columnWidths(this._visibleColumns()));
+		const cols = needed
+		             ? Array.from(this.shadowRoot?.querySelectorAll(".dg-header > .dg-col") || []) as HTMLElement[]
+		             : [];
+		const same = cols.length === this._observedHeaderColumns.length &&
+			cols.every((col, index) => col === this._observedHeaderColumns[index]);
+		if(same)
+		{
+			return;
+		}
+		this._headerColumnResizeObserver?.disconnect();
+		this._observedHeaderColumns = cols;
+		if(!cols.length)
+		{
+			return;
+		}
+		if(!this._headerColumnResizeObserver)
+		{
+			this._headerColumnResizeObserver = new ResizeObserver(() => this._ensureTableColSizes());
+		}
+		for(const col of cols)
+		{
+			this._headerColumnResizeObserver.observe(col);
 		}
 	}
 


### PR DESCRIPTION
## Symptom

In `et2-datagrid`, the column headers do not sit over the columns they label. With a few long header labels, or any column without a configured width, every boundary after the first is shifted — measured up to **102px** of drift on a live instance. Scrolling can move the boundaries further, because the virtualizer only ever renders a window of rows.

## Why

The header (`.dg-header`) and every row (`tbody > tr`) are **separate CSS grids**. They line up only because both resolve the same `--column-sizes` track list. Two things made the two grids resolve that same list to different pixel widths:

### 1. The header cells never opted out of `min-content`

An `Nfr` track is `minmax(auto, Nfr)`, and that `auto` minimum is the item's **min-content**. A grid item that cannot shrink below its content therefore raises its own track and takes the space out of the flexible ones.

The row cells already opt out of this:

```css
tbody td,
tbody th {
    min-width: 0;
    ...
}
```

`.dg-col` never did. Its `.dg-col-inner` clips the label with an ellipsis, but the clipping happens *inside* the cell — the cell itself still reported the full label as its min-content, so a long header label widened its own column **in the header only**, and every following column was off by that much.

Giving `.dg-col` the same `min-width: 0` makes both grids resolve the `fr` tracks purely proportionally, leaving the explicit `minmax(<px>, Nfr)` floors from the column preferences as the only per-column minimum. Headers are now ellipsized to their real column width, exactly like the cells below them.

### 2. `auto` tracks size to each grid's own content

A column without a configured width becomes an `auto` track — and an auto track sizes to *its own grid's* content: the header to its label (121px in the case I measured), the rows to their widest visible value (12px). The leftover space then distributes differently into every `fr` track of the two grids.

`_ensureTableColSizes()` — the existing "keep table columns aligned" hook — now derives the rows' track list from the header: tracks that are `auto` are replaced by the header's resolved pixel width, read from the header's computed `grid-template-columns` (leading meta track skipped, `minmax(...)` tokens split as one token). All other tracks stay identical, so `fr` distribution matches exactly.

Because header widgets render asynchronously, the auto width measured during `updated()` is that of a still-empty header, so a `ResizeObserver` on the header columns re-pins the tracks once content (or a later container resize) settles. Observers are identity-checked per render, attached only while an auto track exists, and disconnected on teardown.

## Two latent bugs this surfaced

- The body-level override was written as `this._body.style["--column-sizes"] = ...`, which is **silently ignored** for CSS custom properties — it has to be `setProperty()`. So the hook never actually did anything.
- Grids with `inherit-column-sizes` (embedded child grids) now explicitly *remove* the body-level override, so the parent grid's tracks keep inheriting. Previously this was only masked by the ignored assignment above.

## Verification

On a live instance: header and row column edges are pixel-identical after the fix — 0px drift on every boundary, previously up to 102px. Grids without auto tracks are unchanged in behaviour (the new code path returns the original track list untouched when the list contains no `auto`). The datagrid row / template-handler / column-state suites pass.

## Risk

Two files, +102/−3, no API change. One CSS declaration on the header cells, and a rewrite of `_ensureTableColSizes()` that is a no-op for grids whose columns all have configured widths.
