### PR TITLE
 Et2TreeDropdown - wait for autoloading before scrollToSelected()

### DIFF
--- a/api/js/etemplate/Et2Tree/Et2Tree.ts
+++ b/api/js/etemplate/Et2Tree/Et2Tree.ts
@@ -1273,7 +1273,11 @@ export class Et2Tree extends Et2WidgetWithSelectMixin(LitElement) implements Fin
 		})
 	}
 
-	protected async finishedLazyLoading()
+	/**
+	 * Resolves once the initial autoloading fetch (if any) has populated _selectOptions.
+	 * Public so callers like Et2TreeDropdown can wait for data before eg. scrolling to a selection.
+	 */
+	public async finishedLazyLoading()
 	{
 		await this.lazyLoading;
 		return this.lazyLoading

--- a/api/js/etemplate/Et2Tree/Et2TreeDropdown.ts
+++ b/api/js/etemplate/Et2Tree/Et2TreeDropdown.ts
@@ -322,7 +322,20 @@ export class Et2TreeDropdown extends SearchMixin<Constructor<any> & Et2InputWidg
 		this.open = true;
 		this.requestUpdate("open", false)
 
-		return this.updateComplete.then(() => { this.openAtSelection && this._tree.scrollToSelected() });
+		return this.updateComplete.then(async() =>
+		{
+			if(!this.openAtSelection)
+			{
+				return;
+			}
+			// Wait for the tree's initial autoloading fetch, otherwise the first show() after page load
+			// races the ajax call: _selectOptions is still empty, nothing is found, and scrollToSelected()
+			// silently does nothing until a later open/close call happens to land after the fetch resolves.
+			await this._tree.finishedLazyLoading();
+			// finishedLazyLoading() resolves when the options are set, the tree still has to render them
+			await this._tree.updateComplete;
+			this._tree.scrollToSelected();
+		});
 	}
 
 	/** Hides the tree. */


### PR DESCRIPTION
### Problem

An `Et2TreeDropdown` with `openAtSelection` does not open at its current
selection the first time it is opened after a page load. The tree opens at the
top instead, and the selection's ancestors stay collapsed. Opening and closing
the dropdown a few times eventually makes it work.

### Cause

`show()` called `scrollToSelected()` right after Lit's `updateComplete`:

```js
return this.updateComplete.then(() => { this.openAtSelection && this._tree.scrollToSelected() });
```

but a tree using `autoloading` does not have its options at that point: they are
fetched by a separate, un-awaited ajax promise (`Et2Tree.lazyLoading`, set up in
`connectedCallback()`). On the first `show()` that fetch usually has not resolved
yet, so `scrollToSelected()` finds no `sl-tree-item[selected]`, returns `false`
and silently does nothing. It only appears to work once an open/close cycle
happens to land after the fetch has finished in the background.

### Fix

`Et2Tree.finishedLazyLoading()` already existed for exactly this purpose, it was
just `protected` - it is now `public`, and `show()` awaits it before scrolling.
It also awaits the tree's `updateComplete` afterwards: the fetch's `.then()` only
assigns `_selectOptions` and calls `requestUpdate()`, so the items still have to
render before they can be found - without that await the lookup only wins by
microtask ordering.

The current selection's ancestors are now reliably expanded and scrolled to on
the very first open.

### Impact

Two files, `api/js/etemplate/Et2Tree/Et2Tree.ts` and
`api/js/etemplate/Et2Tree/Et2TreeDropdown.ts`, +19/-2.

Trees without `autoloading` are unaffected: `lazyLoading` is `undefined` there,
so both added awaits resolve immediately. Nothing changes for
`openAtSelection = false`, which returns before the awaits.

### Testing

Verified in a live instance: category/tree dropdowns using autoloading now open
expanded at the current selection on the first click, previously only after
several open/close cycles.