### PR TITLE
Fix/rest time filters

### DIFF
--- a/addressbook/inc/class.addressbook_groupdav.inc.php
+++ b/addressbook/inc/class.addressbook_groupdav.inc.php
@@ -192,6 +192,8 @@ class addressbook_groupdav extends Api\CalDAV\Handler
 			// callback to query sync-token, after propfind_callbacks / iterator is run and
 			// stored max. modification-time in $this->sync_collection_token
 			$files['sync-token'] = array($this, 'get_sync_collection_token');
+			// report the total to REST clients, it is queried anyway to determine more-results
+			$files['total'] = array($this, 'getTotal');
 			$files['sync-token-params'] = array($path, $user);
 
 			$this->sync_collection_token = $this->more_results = null;
@@ -300,6 +302,7 @@ class addressbook_groupdav extends Api\CalDAV\Handler
 		for($chunk=0; ($contacts =& $this->bo->search($search, $cols, $order, '', '', False, 'AND',
 			[$chunk*self::CHUNK_SIZE, self::CHUNK_SIZE], $filter)); ++$chunk)
 		{
+			$this->total = $this->bo->total;
 			// filter[tid] === null also returns no longer shared contacts, to remove them from devices, we need to mark them here as deleted
 			// to do so we need to read not deleted sharing info of potential candidates (not deleted and no regular access), as search does NOT
 			$id2key = [];
@@ -495,7 +498,36 @@ class addressbook_groupdav extends Api\CalDAV\Handler
 		// in case of JSON/REST API pass filters to report
 		if (Api\CalDAV::isJSON() && !empty($options['filters']) && is_array($options['filters']))
 		{
-			$filters += $options['filters'];    // using += to no allow overwriting existing filters
+			foreach($options['filters'] as $name => $value)
+			{
+				// CalDAV::jsonIndex() appends filters[start] / filters[end] as a time-range under an integer key
+				if (!is_string($name))
+				{
+					if (is_array($value) && ($value['name'] ?? null) === 'time-range')
+					{
+						$filters[] = $this->jsonTimeRangeFilter($value['attrs'], 'contact_modified');
+					}
+					continue;
+				}
+				switch($name)
+				{
+					case 'order':
+						$filters['order'] = $this->jsonOrderFilter($value);
+						break;
+					case 'search':
+					case 'filter':
+						$filters[$name] ??= $value;     // handled by Api\Contacts::search()
+						break;
+					default:
+						if ($name[0] !== '#')
+						{
+							// reject an unknown filter with a helpful 400, instead of an SQL error
+							$this->assertFilterColumn($name, $name);
+						}
+						$filters[$name] ??= $value;     // ??= to not allow overwriting existing filters
+						break;
+				}
+			}
 		}
 		elseif (!empty($options['filters']))
 		{

--- a/api/src/CalDAV.php
+++ b/api/src/CalDAV.php
@@ -1117,6 +1117,15 @@ class CalDAV extends HTTP_WebDAV_Server
 			exit;
 		}
 
+		// REST: /<app>/count reports just the number of entries matching the filters, so a client can
+		// answer "how many ..." without transferring them. Has to be checked before _parse_path(),
+		// which would take "count" for an entry-id.
+		if (($json = self::isJSON()) && preg_match('#^(/[^/]+)?/[a-zA-Z0-9_-]+/count$#', $options['path']))
+		{
+			$options['path'] = substr($options['path'], 0, -strlen('count'));
+			return $this->jsonIndex($options, $json === 'pretty', true);
+		}
+
 		$id = $app = $user = null;
 		if (!$this->_parse_path($options['path'],$id,$app,$user) || $app == 'principals')
 		{
@@ -1173,7 +1182,7 @@ class CalDAV extends HTTP_WebDAV_Server
 	 * @param bool $pretty =false true: pretty-print JSON
 	 * @return bool|string|void
 	 */
-	protected function jsonIndex(array $options, bool $pretty)
+	protected function jsonIndex(array $options, bool $pretty, bool $count_only=false)
 	{
 		header('Content-Type: application/json; charset=utf-8');
 		$is_addressbook = strpos($options['path'], '/addressbook') !== false;
@@ -1192,6 +1201,12 @@ class CalDAV extends HTTP_WebDAV_Server
 			'root' => ['name' => null],
 		);
 
+		// a count only needs the total, which the handlers query anyway to determine more-results:
+		// ask for a single row, so no entry gets serialized
+		if ($count_only)
+		{
+			$_GET['nresults'] = 1;
+		}
 		// implement default number of matches from OpenAPI configuration, if nothing is specified in the request
 		if (!isset($_GET['nresults']))
 		{
@@ -1265,6 +1280,17 @@ class CalDAV extends HTTP_WebDAV_Server
 			$nl = "\n";
 			$sp = ' ';
 		}
+		if ($count_only)
+		{
+			// the generator is lazy: it has to run for the handler to query the total
+			foreach($files['files'] as $unused)
+			{
+				unset($unused);
+			}
+			echo '{'.$nl.$tab.'"total":'.$sp.(int)self::resolveTotal($files).$nl.'}'."\n";
+			return '200 Ok';
+		}
+
 		// set start as prefix, to no have it in front of exceptions
 		$prefix = '{'.$nl.$tab.'"responses":'.$sp.'{'.$nl;
 		foreach($files['files'] as $resource)
@@ -1299,6 +1325,13 @@ class CalDAV extends HTTP_WebDAV_Server
 			$prefix = ",$nl";
 		}
 		echo "$nl$tab}";
+		// total number of entries matching the filter, so a client can answer "how many ..."
+		// without having to transfer them
+		if (isset($files['total']) && ($total = self::resolveTotal($files)) !== null)
+		{
+			echo $prefix.$tab.'"total": '.(int)$total;
+			$prefix = ",$nl";
+		}
 		// add sync-token and more-results to response
 		if (isset($files['sync-token']))
 		{
@@ -1308,6 +1341,18 @@ class CalDAV extends HTTP_WebDAV_Server
 		echo "$nl}\n";
 
 		return '200 Ok';    // not returning true
+	}
+
+	/**
+	 * Resolve the total reported by a handler, which is only known after its generator ran
+	 *
+	 * @param array $files as filled by REPORT()
+	 * @return ?int
+	 */
+	protected static function resolveTotal(array $files): ?int
+	{
+		$total = $files['total'] ?? null;
+		return is_callable($total) ? call_user_func($total) : $total;
 	}
 
 	/**
@@ -2649,6 +2694,19 @@ class CalDAV extends HTTP_WebDAV_Server
 	 * @param \Exception|\Error $e
 	 * @param bool $exit true: exit, false: do NOT exist, just return
 	 */
+	/**
+	 * Client errors an app can raise as exception-code, to be reported as such instead of a 500
+	 */
+	const CLIENT_ERROR_STATUS = [
+		400 => 'Bad Request',
+		403 => 'Forbidden',
+		404 => 'Not Found',
+		409 => 'Conflict',
+		412 => 'Precondition Failed',
+		415 => 'Unsupported Media Type',
+		422 => 'Unprocessable Entity',
+	];
+
 	public static function exception_handler($e, bool $exit=true)
 	{
 		// logging exception as regular egw_execption_hander does
@@ -2661,6 +2719,12 @@ class CalDAV extends HTTP_WebDAV_Server
 			if (is_a($e, JsParseException::class))
 			{
 				$status = '422 Unprocessable Entity';
+			}
+			// a client error carries its status as exception-code, reporting it as 500 tells the
+			// client to retry, when it should fix its request instead
+			elseif (isset(self::CLIENT_ERROR_STATUS[$code = $e->getCode()]))
+			{
+				$status = $code.' '.self::CLIENT_ERROR_STATUS[$code];
 			}
 			else
 			{

--- a/api/src/CalDAV.php
+++ b/api/src/CalDAV.php
@@ -1198,11 +1198,13 @@ class CalDAV extends HTTP_WebDAV_Server
 			$_GET['nresults'] = OpenAPI::defaultMatches();
 		}
 
-		// sync-collection report via GET parameter sync-token
-		if (isset($_GET['sync-token']))
+		// sync-collection report via GET parameter sync-token, or whenever the number of results is
+		// limited: the handlers only evaluate nresults for a sync-collection, so a plain listing was
+		// unbounded even with nresults given - an empty sync-token requests the initial full sync
+		if (isset($_GET['sync-token']) || isset($_GET['nresults']))
 		{
 			$propfind_options['root'] = ['name' => 'sync-collection'];
-			$propfind_options['other'][] = ['name' => 'sync-token', 'data' => $_GET['sync-token']];
+			$propfind_options['other'][] = ['name' => 'sync-token', 'data' => $_GET['sync-token'] ?? ''];
 			$propfind_options['other'][] = ['name' => 'sync-level', 'data' => $_GET['sync-level'] ?? 1];
 
 			// clients want's pagination

--- a/api/src/CalDAV/Handler.php
+++ b/api/src/CalDAV/Handler.php
@@ -129,6 +129,130 @@ abstract class Handler
 	const SYNC_TOKEN_OFFSET_DELIMITER = '_';
 
 	/**
+	 * Total number of entries matching the current filter, or null if not (yet) known
+	 *
+	 * Set by the handlers from their bo-class, after a limited query determined it anyway to
+	 * calculate $more_results. CalDAV::jsonIndex() reports it as "total" to REST clients, so a
+	 * client can answer "how many ..." without transferring the entries.
+	 *
+	 * @var ?int
+	 */
+	public $total;
+
+	/**
+	 * Get the total number of matching entries, for CalDAV::jsonIndex()
+	 *
+	 * Called after the propfind-generator ran, as $total is only known then.
+	 *
+	 * @return ?int
+	 */
+	public function getTotal(): ?int
+	{
+		// an empty collection never enters the paging loop, so $total was never assigned there
+		return $this->total ?? (isset($this->bo->total) ? (int)$this->bo->total : null);
+	}
+
+	/**
+	 * Columns which may be used as a JSON/REST filter
+	 *
+	 * Used to reject an unknown filter with a helpful "400 Bad Request", instead of passing a
+	 * non-existing column on to the database, which fails with a "500 Internal Server Error".
+	 *
+	 * @return array of column-names, empty array if the app can not tell (--> no validation)
+	 */
+	protected function jsonFilterColumns(): array
+	{
+		if (is_array($this->bo->db_cols ?? null))
+		{
+			return array_keys($this->bo->db_cols);
+		}
+		if (is_array($this->bo->so->db_cols ?? null))
+		{
+			return array_keys($this->bo->so->db_cols);
+		}
+		// Api\Contacts keeps its storage in somain
+		if (is_array($this->bo->somain->db_cols ?? null))
+		{
+			return array_keys($this->bo->somain->db_cols);
+		}
+		return [];
+	}
+
+	/**
+	 * Check a filter maps to an existing column, throwing a helpful exception if it does not
+	 *
+	 * @param string $column column the filter was mapped to
+	 * @param string $name filter-name as given by the client
+	 * @throws Api\Exception 400 naming the valid filters
+	 */
+	protected function assertFilterColumn(string $column, string $name): void
+	{
+		if (!($columns = $this->jsonFilterColumns()) || in_array($column, $columns, true))
+		{
+			return;
+		}
+		sort($columns);
+		throw new Api\Exception("Unknown filter '$name'! Valid filters are: ".implode(', ', $columns), 400);
+	}
+
+	/**
+	 * Turn the time-range CalDAV::jsonIndex() generates from filters[start] / filters[end] into SQL
+	 *
+	 * jsonIndex() appends it under an integer key, as CalDAV filters are a list, not a hash. Apps
+	 * with a single date-column can use this; calendar and InfoLog have their own, richer handling.
+	 *
+	 * @param array $attrs with keys start and/or end
+	 * @param string $column date-column to filter on, e.g. "ts_start"
+	 * @return string SQL fragment
+	 * @throws Api\Exception 400 if neither start nor end is given
+	 */
+	protected function jsonTimeRangeFilter(array $attrs, string $column): string
+	{
+		$sql = [];
+		foreach(['start' => '>=', 'end' => '<='] as $name => $op)
+		{
+			if (!empty($attrs[$name]))
+			{
+				try {
+					$date = new Api\DateTime($attrs[$name]);
+				}
+				catch (\Exception $e) {
+					throw new Api\Exception("Invalid filters[$name] '$attrs[$name]', use a date like 2026-01-31!", 400);
+				}
+				// a bare date as end means the whole day: filters[end]=2026-01-31 has to match entries
+				// from that day too, not just the ones at exactly 00:00
+				if ($name === 'end' && preg_match('/^\d{4}-\d{2}-\d{2}$/', trim($attrs[$name])))
+				{
+					$date->setTime(23, 59, 59);
+				}
+				$sql[] = $column.$op.(int)$date->format('ts');
+			}
+		}
+		if (!$sql)
+		{
+			throw new Api\Exception('filters[start] and/or filters[end] require a date like 2026-01-31!', 400);
+		}
+		return '('.implode(' AND ', $sql).')';
+	}
+
+	/**
+	 * Validate filters[order], as it is passed on as SQL
+	 *
+	 * @param string $value "<column>" optionally followed by " ASC" or " DESC"
+	 * @return string
+	 * @throws Api\Exception 400 for an unknown column or direction
+	 */
+	protected function jsonOrderFilter(string $value): string
+	{
+		if (!preg_match('/^([a-z0-9_]+\.)?([a-z0-9_]+)( +(ASC|DESC))?$/i', trim($value), $matches))
+		{
+			throw new Api\Exception("Invalid filters[order] '$value', must be '<column> [ASC|DESC]'!", 400);
+		}
+		$this->assertFilterColumn($matches[2], 'order');
+		return $matches[2].(empty($matches[4]) ? '' : ' '.strtoupper($matches[4]));
+	}
+
+	/**
 	 * Constructor
 	 *
 	 * @param string $app 'calendar', 'addressbook' or 'infolog'

--- a/api/src/CalDAV/OpenAPI.php
+++ b/api/src/CalDAV/OpenAPI.php
@@ -30,6 +30,11 @@ class OpenAPI
 	];
 
 	/**
+	 * HTTP methods of an OpenAPI path-item object, every other key (parameters, summary, description, servers, $ref) is no operation
+	 */
+	const HTTP_METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
+
+	/**
 	 * Scan directory for app-specific JSON files and merge them into a single OpenAPI spec
 	 *
 	 * @param bool $inline_parameters true: replace parameter references with the actual data
@@ -86,16 +91,28 @@ class OpenAPI
 		{
 			if (str_ends_with($file, ".json"))
 			{
-				// if we're authenticated only show API's of apps the user has access too or are independent of an app like "links.json"
-				if (isset($GLOBALS['egw_info']['apps'][$app=basename($file, '.json')]) &&
-					isset($GLOBALS['egw_info']['user']['apps']) && !isset($GLOBALS['egw_info']['user']['apps'][$app]))
+				$app_json = json_decode(file_get_contents($base_dir.'/'.$file), true);
+
+				// if we know the installed apps, only show API's of apps the user has access too,
+				// but always keep app-independent descriptions like "links.json"
+				if (!empty($GLOBALS['egw_info']['apps']) && self::isAppSpecific($app=basename($file, '.json'), $app_json) &&
+					(!isset($GLOBALS['egw_info']['apps'][$app]) ||   // app is not installed
+						isset($GLOBALS['egw_info']['user']['apps']) && !isset($GLOBALS['egw_info']['user']['apps'][$app])))
 				{
 					continue;
 				}
-				$app_json = json_decode(file_get_contents($base_dir.'/'.$file), true);
 
 				foreach($app_json['paths'] as $path => &$methods)
 				{
+					// a path-item can contain more than operations: parameters, summary, description, servers or $ref
+					$path_parameters = $methods['parameters'] ?? [];
+					foreach(array_keys($methods) as $key)
+					{
+						if (!in_array(strtolower($key), self::HTTP_METHODS, true))
+						{
+							unset($methods[$key]);
+						}
+					}
 					foreach($methods as $method => &$data)
 					{
 						if (empty($data['operationId']) || isset($operationIds[$data['operationId']]))
@@ -110,7 +127,12 @@ class OpenAPI
 							unset($methods[$method]);
 							continue;
 						}
-						if ($inline_parameters)
+						// path-level parameters apply to all operations of that path, operation-level ones take precedence
+						if ($path_parameters)
+						{
+							$data['parameters'] = self::mergeParameters($path_parameters, $data['parameters'] ?? [], $app_json);
+						}
+						if ($inline_parameters && !empty($data['parameters']))
 						{
 							foreach ($data['parameters'] as &$parameter)
 							{
@@ -123,13 +145,16 @@ class OpenAPI
 									$parameter = $app_json['components']['parameters'][$name];
 								}
 							}
+							unset($parameter);
 						}
 					}
+					unset($data);
 					if (!$methods)
 					{
 						unset($app_json['paths'][$path]);
 					}
 				}
+				unset($methods);
 				if ($inline_parameters)
 				{
 					unset($app_json['parameters']);
@@ -145,6 +170,63 @@ class OpenAPI
 			}
 		}
 		return $json;
+	}
+
+	/**
+	 * Check if an OpenAPI description belongs to a single app, or is app-independent like "links.json"
+	 *
+	 * App-specific descriptions have at least one path under /<app>, app-independent ones use a placeholder like /{app}.
+	 *
+	 * @param string $app name of the JSON-file without extension
+	 * @param array $app_json decoded OpenAPI description
+	 * @return bool
+	 */
+	protected static function isAppSpecific(string $app, array $app_json): bool
+	{
+		foreach(array_keys($app_json['paths'] ?? []) as $path)
+		{
+			if ($path === '/'.$app || str_starts_with($path, '/'.$app.'/'))
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Merge path-level parameters into the parameters of a single operation
+	 *
+	 * Operation-level parameters take precedence over path-level ones with the same name and location.
+	 *
+	 * @param array $path_parameters parameters of the path-item, applying to all its operations
+	 * @param array $parameters parameters of the operation itself
+	 * @param array $app_json decoded OpenAPI description to resolve references for the comparison
+	 * @return array
+	 */
+	protected static function mergeParameters(array $path_parameters, array $parameters, array $app_json): array
+	{
+		$merged = [];
+		foreach(array_merge($path_parameters, $parameters) as $parameter)
+		{
+			$merged[self::parameterKey($parameter, $app_json)] = $parameter;
+		}
+		return array_values($merged);
+	}
+
+	/**
+	 * Get "<name>:<in>" identifying a parameter, resolving a reference to components/parameters
+	 *
+	 * @param array $parameter
+	 * @param array $app_json
+	 * @return string
+	 */
+	protected static function parameterKey(array $parameter, array $app_json): string
+	{
+		if (isset($parameter['$ref']) && str_starts_with($parameter['$ref'], '#/components/parameters/'))
+		{
+			$parameter = $app_json['components']['parameters'][explode('/', $parameter['$ref'])[3] ?? ''] ?? $parameter;
+		}
+		return ($parameter['name'] ?? $parameter['$ref'] ?? '').':'.($parameter['in'] ?? '');
 	}
 
 	/**

--- a/api/src/Db.php
+++ b/api/src/Db.php
@@ -1722,7 +1722,12 @@ class Db
 				if (!is_int($key) && is_array($column_definitions) && !isset($column_definitions[$key]) &&
 					(!preg_match('/^([a-z0-9_]+)\.([a-z0-9_]+)$/i',$key,$matches) || !isset($column_definitions[$matches[2]])))
 				{
-					throw new Db\Exception\InvalidSql("db::column_data_implode('$glue',".print_r($array,True).",'$use_key',".print_r($only,True).",<pre>".print_r($column_definitions,True)."</pre><b>nothing known about column '$key'!</b>");
+					// the full arrays are valuable for debugging, but this exception message is echoed
+					// to REST/CalDAV clients, so keep the table schema and the given values out of it
+					error_log(__METHOD__."('$glue',".print_r($array,True).",'$use_key',".print_r($only,True).
+						") nothing known about column '$key', known columns: ".
+						implode(', ', array_keys((array)$column_definitions)));
+					throw new Db\Exception\InvalidSql("nothing known about column '$key'!");
 				}
 				$column_type = is_array($column_definitions) ? ($column_definitions[$col]['type'] ?? false) : False;
 				$not_null = is_array($column_definitions) && isset($column_definitions[$col]['nullable']) ? !$column_definitions[$col]['nullable'] : false;

--- a/calendar/inc/class.calendar_groupdav.inc.php
+++ b/calendar/inc/class.calendar_groupdav.inc.php
@@ -217,6 +217,8 @@ class calendar_groupdav extends Api\CalDAV\Handler
 			}
 			$filter[$name] = $this->bo->now + 24*3600*($name == 'start' ? -1 : 1)*abs($value);
 		}
+		// remember the default future-limit, to tell it apart from an end-date requested by the client below
+		$default_end = $filter['end'];
 		if ($this->client_shared_uid_exceptions)	// do NOT return (non-virtual) exceptions
 		{
 			$filter['query'] = array('cal_reference' => 0);
@@ -269,8 +271,13 @@ class calendar_groupdav extends Api\CalDAV\Handler
 
 			$filter['order'] = 'cal_modified ASC';	// return oldest modifications first
 			$filter['sync-collection'] = true;
-			// no end-date / limit into the future, as unchanged entries would never be transferted later on
-			unset($filter['end']);
+			// no default end-date / limit into the future, as unchanged entries would never be transferted
+			// later on - an end-date explicitly requested by the client is kept, dropping it silently
+			// widened every filtered query issued together with a sync-token
+			if (($filter['end'] ?? null) === $default_end)
+			{
+				unset($filter['end']);
+			}
 		}
 
 		// check if we have to return the full calendar data or just the etag's

--- a/calendar/inc/class.calendar_groupdav.inc.php
+++ b/calendar/inc/class.calendar_groupdav.inc.php
@@ -544,6 +544,85 @@ class calendar_groupdav extends Api\CalDAV\Handler
 	}
 
 	/**
+	 * Apply the JSON/REST API filters to the calendar search parameters
+	 *
+	 * Unlike the CalDAV XML filters handled in _report_filters(), these arrive as a plain
+	 * name => value array. filters[start] / filters[end] have already been turned into a
+	 * synthetic time-range element under an integer key by Api\CalDAV::jsonIndex().
+	 *
+	 * Entries outside filters[start]/filters[end] keep the collection's default -100/+365 day
+	 * window, same as an unfiltered listing.
+	 *
+	 * @param array $filters filters from the request
+	 * @param array& $cal_filters
+	 * @throws Api\Exception 400 for an invalid linked-filter
+	 */
+	private function jsonReportFilters(array $filters, array &$cal_filters)
+	{
+		$search = $linked_ids = null;
+
+		foreach($filters as $name => $value)
+		{
+			if (!is_string($name))
+			{
+				if (is_array($value) && ($value['name'] ?? null) === 'time-range')
+				{
+					if (!empty($value['attrs']['start']))
+					{
+						$cal_filters['start'] = $this->vCalendar->_parseDateTime($value['attrs']['start']);
+					}
+					if (!empty($value['attrs']['end']))
+					{
+						$cal_filters['end'] = $this->vCalendar->_parseDateTime($value['attrs']['end']);
+					}
+				}
+				continue;
+			}
+			switch($name)
+			{
+				case 'search':
+					// string: free-text over cal_title, cal_description and cal_location
+					// array: <db-column> => <value>, integer keys stripped as they'd be used as SQL
+					$search = is_array($value) ?
+						array_filter($value, static fn($key) => !is_int($key), ARRAY_FILTER_USE_KEY) : $value;
+					break;
+
+				case 'linked':
+					if (!preg_match('/^([a-z_]+):(\d+)$/i', $value, $matches) ||
+						!isset($GLOBALS['egw_info']['user']['apps'][$matches[1]]) || (int)$matches[2] <= 0)
+					{
+						throw new Api\Exception("Invalid linked-filter '$value', should be '<app-name>:<nummeric-ID>'!", 400);
+					}
+					// [0] to return nothing instead of everything, if there are no links
+					$linked_ids = Api\Link::get_links($matches[1], $matches[2], 'calendar') ?: [0];
+					break;
+
+				default:
+					$this->caldav->log(__METHOD__."() unknown filter '$name' --> ignored");
+					break;
+			}
+		}
+
+		// calendar_bo::search() only understands one "query": either a free-text string searched over
+		// title/description/location, or an array of <db-column> => <value>. sql_filter is not usable
+		// here, calendar_bo::search() deliberately overwrites it from its own 2nd argument.
+		if (isset($search) && isset($linked_ids) && !is_array($search))
+		{
+			throw new Api\Exception("filters[linked] can not be combined with a free-text filters[search] for calendar", 400);
+		}
+		if (isset($linked_ids))
+		{
+			$search = (array)($search ?? []);
+			// table-qualified, cal_id exists in egw_cal and egw_cal_user
+			$search['egw_cal.cal_id'] = $linked_ids;
+		}
+		if (isset($search))
+		{
+			$cal_filters['query'] = $search;
+		}
+	}
+
+	/**
 	 * Process the filters from the CalDAV REPORT request
 	 *
 	 * @param array $options
@@ -554,7 +633,13 @@ class calendar_groupdav extends Api\CalDAV\Handler
 	 */
 	function _report_filters($options, &$cal_filters, $id, &$nresults)
 	{
-		if ($options['filters'])
+		// JSON/REST API: filters arrive as a plain name => value array, not as CalDAV XML elements,
+		// so they would all fall through the switch below and be silently ignored
+		if (Api\CalDAV::isJSON() && !empty($options['filters']) && is_array($options['filters']))
+		{
+			$this->jsonReportFilters($options['filters'], $cal_filters);
+		}
+		elseif ($options['filters'])
 		{
 			// unset default start & end
 			$cal_start = $cal_filters['start']; unset($cal_filters['start']);

--- a/calendar/inc/class.calendar_groupdav.inc.php
+++ b/calendar/inc/class.calendar_groupdav.inc.php
@@ -265,6 +265,8 @@ class calendar_groupdav extends Api\CalDAV\Handler
 			// callback to query sync-token, after propfind_callbacks / iterator is run and
 			// stored max. modification-time in $this->sync_collection_token
 			$files['sync-token'] = array($this, 'get_sync_collection_token');
+			// report the total to REST clients, it is queried anyway to determine more-results
+			$files['total'] = array($this, 'getTotal');
 			$files['sync-token-params'] = array($path, $user);
 
 			$this->sync_collection_token = $this->more_results = null;
@@ -354,6 +356,7 @@ class calendar_groupdav extends Api\CalDAV\Handler
 				'date_format' => 'object',
 			]+$filter)); ++$chunk)
 		{
+			$this->total = $this->bo->total;
 			foreach($events as $event)
 			{
 				$no_active_participants = !$this->hasActiveParticipants($event, $filter['users'], $exceptions);

--- a/doc/openapi/addressbook.json
+++ b/doc/openapi/addressbook.json
@@ -50,6 +50,15 @@
             "$ref": "#/components/parameters/filters_linked"
           },
           {
+            "$ref": "#/components/parameters/filters_start"
+          },
+          {
+            "$ref": "#/components/parameters/filters_end"
+          },
+          {
+            "$ref": "#/components/parameters/filters_order"
+          },
+          {
             "name": "Accept",
             "in": "header",
             "required": true,
@@ -83,7 +92,9 @@
         }
       },
       "post": {
-        "tags": ["Addressbook"],
+        "tags": [
+          "Addressbook"
+        ],
         "summary": "Create a new contact in the users default addressbook",
         "description": "Adds a new contact to the addressbook. The Location header in the response gives the URL of the new resource.",
         "operationId": "createContact",
@@ -94,7 +105,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["application/json","application/json-patch+json"]
+              "enum": [
+                "application/json",
+                "application/json-patch+json"
+              ]
             }
           }
         ],
@@ -144,7 +158,9 @@
     },
     "/{username}/addressbook/": {
       "get": {
-        "tags": ["Addressbook"],
+        "tags": [
+          "Addressbook"
+        ],
         "summary": "List or search contacts in the given users addressbook",
         "description": "Returns all contacts in the user's addressbook. Supports filtering, pagination, and custom property selection.",
         "operationId": "listContacts",
@@ -173,7 +189,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["application/json", "application/pretty+json"]
+              "enum": [
+                "application/json",
+                "application/pretty+json"
+              ]
             },
             "description": "Accept header for JSON or pretty-printed JSON"
           }
@@ -198,7 +217,9 @@
         }
       },
       "post": {
-        "tags": ["Addressbook"],
+        "tags": [
+          "Addressbook"
+        ],
         "summary": "Create a new contact in the given users addressbook",
         "description": "Adds a new contact to the addressbook. The Location header in the response gives the URL of the new resource.",
         "operationId": "createUserContact",
@@ -212,7 +233,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["application/json","application/json-patch+json"]
+              "enum": [
+                "application/json",
+                "application/json-patch+json"
+              ]
             }
           }
         ],
@@ -262,7 +286,9 @@
     },
     "/addressbook/{id}": {
       "get": {
-        "tags": ["Addressbook"],
+        "tags": [
+          "Addressbook"
+        ],
         "summary": "Get a single contact",
         "description": "Retrieves a single contact by ID.",
         "operationId": "getContact",
@@ -276,7 +302,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["application/json", "application/pretty+json"]
+              "enum": [
+                "application/json",
+                "application/pretty+json"
+              ]
             }
           }
         ],
@@ -300,7 +329,9 @@
         }
       },
       "put": {
-        "tags": ["Addressbook"],
+        "tags": [
+          "Addressbook"
+        ],
         "summary": "Replace a contact",
         "description": "Replaces all attributes of a contact. Requires all attributes to be specified. If the ID is a UID, it will update the existing contact or create a new one if it does not exist.",
         "operationId": "replaceContact",
@@ -314,7 +345,9 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["application/json"]
+              "enum": [
+                "application/json"
+              ]
             }
           }
         ],
@@ -356,7 +389,9 @@
         }
       },
       "patch": {
-        "tags": ["Addressbook"],
+        "tags": [
+          "Addressbook"
+        ],
         "summary": "Partially update a contact",
         "description": "Updates only the specified attributes of a contact. To unset a field, patch its value to `null`.",
         "operationId": "updateContact",
@@ -370,7 +405,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["application/json","application/json-patch+json"]
+              "enum": [
+                "application/json",
+                "application/json-patch+json"
+              ]
             }
           }
         ],
@@ -405,7 +443,9 @@
         }
       },
       "delete": {
-        "tags": ["Addressbook"],
+        "tags": [
+          "Addressbook"
+        ],
         "summary": "Delete a contact",
         "description": "Deletes a contact by ID.",
         "operationId": "deleteContact",
@@ -423,6 +463,60 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/addressbook/count": {
+      "get": {
+        "tags": [
+          "Addressbook"
+        ],
+        "summary": "Count contacts",
+        "description": "Returns ONLY the number of contacts matching the filters, as {\"total\": <n>}. Use this to answer \"how many ...\" questions instead of listing entries: it accepts the same filters[...] parameters as the listing, but transfers no entries at all, so it works on collections of any size. Combine with filters[start] and filters[end] for a time period.",
+        "operationId": "countContacts",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/filters_search"
+          },
+          {
+            "$ref": "#/components/parameters/filters_linked"
+          },
+          {
+            "$ref": "#/components/parameters/filters_start"
+          },
+          {
+            "$ref": "#/components/parameters/filters_end"
+          },
+          {
+            "$ref": "#/components/parameters/filters_order"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Number of matching entries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "total": {
+                      "type": "integer",
+                      "description": "number of matching entries"
+                    }
+                  },
+                  "required": [
+                    "total"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid filter"
+          },
+          "401": {
+            "description": "Unauthorized"
           }
         }
       }
@@ -504,17 +598,51 @@
           "type": "string"
         },
         "description": "Search entries from other apps linked to the given one. Example: filters[linked]=<app-name>:<app-id>"
+      },
+      "filters_start": {
+        "name": "filters[start]",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "date"
+        },
+        "description": "Only return contacts on or after this date, matched against the last modification (contact_modified), as YYYY-MM-DD. REQUIRED whenever the question refers to a time period: resolve phrases like 'this week', 'last month' or 'the last 3 months' to explicit dates and pass them. Example: filters[start]=2026-01-01"
+      },
+      "filters_end": {
+        "name": "filters[end]",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "date"
+        },
+        "description": "Only return contacts on or before this date, matched against the last modification (contact_modified), as YYYY-MM-DD. A bare date covers the whole day. Pass together with filters[start] for any time-bounded question. Example: filters[end]=2026-03-31"
+      },
+      "filters_order": {
+        "name": "filters[order]",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Sort order as '<db-column>' optionally followed by ' ASC' or ' DESC'. Default is contact_id ASC. An unknown column is rejected with 400 and a list of the valid ones."
       }
     },
     "schemas": {
       "Contact": {
         "type": "object",
-        "required": ["fullName"],
+        "required": [
+          "fullName"
+        ],
         "description": "Contact in JsContact format. uid is auto-generated if omitted. @type defaults to 'Card'. prodId is set by the server.",
         "properties": {
           "@type": {
             "type": "string",
-            "enum": ["Card", "CardGroup"],
+            "enum": [
+              "Card",
+              "CardGroup"
+            ],
             "description": "Type of the resource. Defaults to 'Card' if omitted."
           },
           "uid": {
@@ -537,7 +665,10 @@
           },
           "kind": {
             "type": "string",
-            "enum": ["individual", "organization"],
+            "enum": [
+              "individual",
+              "organization"
+            ],
             "description": "Kind of contact (individual or organization)"
           },
           "name": {
@@ -760,7 +891,9 @@
       "CustomField": {
         "type": "object",
         "description": "A single custom field. Custom-field names are user-/admin-defined (configured under Admin >> Custom fields). For create/update (flat POST or PATCH) send only the custom-field name with its value, e.g. `\"egroupware.org:customfields/<name>\": <value>`. On read an object is returned carrying the field's `type`, `label` and always a `value` attribute holding the actual value.",
-        "required": ["value"],
+        "required": [
+          "value"
+        ],
         "properties": {
           "value": {
             "description": "The actual value of the custom field. Its JSON type depends on the custom-field's `type` (e.g. string, number or array for `select`)."
@@ -787,15 +920,30 @@
       },
       "NameComponent": {
         "type": "object",
-        "required": ["@type", "type", "value"],
+        "required": [
+          "@type",
+          "type",
+          "value"
+        ],
         "properties": {
           "@type": {
             "type": "string",
-            "enum": ["NameComponent"]
+            "enum": [
+              "NameComponent"
+            ]
           },
           "type": {
             "type": "string",
-            "enum": ["title", "given", "given2", "surname", "surname2", "credential", "generation", "separator"]
+            "enum": [
+              "title",
+              "given",
+              "given2",
+              "surname",
+              "surname2",
+              "credential",
+              "generation",
+              "separator"
+            ]
           },
           "value": {
             "type": "string"
@@ -804,11 +952,16 @@
       },
       "Organization": {
         "type": "object",
-        "required": ["@type", "name"],
+        "required": [
+          "@type",
+          "name"
+        ],
         "properties": {
           "@type": {
             "type": "string",
-            "enum": ["Organization"]
+            "enum": [
+              "Organization"
+            ]
           },
           "name": {
             "type": "string"
@@ -823,11 +976,16 @@
       },
       "Title": {
         "type": "object",
-        "required": ["@type", "title"],
+        "required": [
+          "@type",
+          "title"
+        ],
         "properties": {
           "@type": {
             "type": "string",
-            "enum": ["Title"]
+            "enum": [
+              "Title"
+            ]
           },
           "title": {
             "type": "string"
@@ -839,11 +997,16 @@
       },
       "EmailAddress": {
         "type": "object",
-        "required": ["@type", "email"],
+        "required": [
+          "@type",
+          "email"
+        ],
         "properties": {
           "@type": {
             "type": "string",
-            "enum": ["EmailAddress"]
+            "enum": [
+              "EmailAddress"
+            ]
           },
           "email": {
             "type": "string"
@@ -861,11 +1024,16 @@
       },
       "Phone": {
         "type": "object",
-        "required": ["@type", "phone"],
+        "required": [
+          "@type",
+          "phone"
+        ],
         "properties": {
           "@type": {
             "type": "string",
-            "enum": ["Phone"]
+            "enum": [
+              "Phone"
+            ]
           },
           "phone": {
             "type": "string"
@@ -889,11 +1057,17 @@
       },
       "Resource": {
         "type": "object",
-        "required": ["@type", "resource", "type"],
+        "required": [
+          "@type",
+          "resource",
+          "type"
+        ],
         "properties": {
           "@type": {
             "type": "string",
-            "enum": ["Resource"]
+            "enum": [
+              "Resource"
+            ]
           },
           "resource": {
             "type": "string"
@@ -911,11 +1085,15 @@
       },
       "Address": {
         "type": "object",
-        "required": ["@type"],
+        "required": [
+          "@type"
+        ],
         "properties": {
           "@type": {
             "type": "string",
-            "enum": ["Address"]
+            "enum": [
+              "Address"
+            ]
           },
           "locality": {
             "type": "string"
@@ -951,15 +1129,24 @@
       },
       "StreetComponent": {
         "type": "object",
-        "required": ["@type", "type", "value"],
+        "required": [
+          "@type",
+          "type",
+          "value"
+        ],
         "properties": {
           "@type": {
             "type": "string",
-            "enum": ["StreetComponent"]
+            "enum": [
+              "StreetComponent"
+            ]
           },
           "type": {
             "type": "string",
-            "enum": ["name", "separator"]
+            "enum": [
+              "name",
+              "separator"
+            ]
           },
           "value": {
             "type": "string"
@@ -968,11 +1155,17 @@
       },
       "File": {
         "type": "object",
-        "required": ["@type", "href", "mediaType"],
+        "required": [
+          "@type",
+          "href",
+          "mediaType"
+        ],
         "properties": {
           "@type": {
             "type": "string",
-            "enum": ["File"]
+            "enum": [
+              "File"
+            ]
           },
           "href": {
             "type": "string",
@@ -985,15 +1178,23 @@
       },
       "Anniversary": {
         "type": "object",
-        "required": ["@type", "type", "date"],
+        "required": [
+          "@type",
+          "type",
+          "date"
+        ],
         "properties": {
           "@type": {
             "type": "string",
-            "enum": ["Anniversary"]
+            "enum": [
+              "Anniversary"
+            ]
           },
           "type": {
             "type": "string",
-            "enum": ["birth"]
+            "enum": [
+              "birth"
+            ]
           },
           "date": {
             "type": "string",

--- a/doc/openapi/calendar.json
+++ b/doc/openapi/calendar.json
@@ -31,7 +31,7 @@
           "Calendar"
         ],
         "summary": "List all events of the user",
-        "description": "Returns all events in the user's calendar. Supports filtering, pagination, and custom property selection.",
+        "description": "Returns events from the user's calendar. Without filters[start]/filters[end] only events between 100 days in the past and 365 days in the future are returned. To bound the response size, send sync-token= (empty) together with nresults=20; the response then carries a more-results flag and a sync-token for the next chunk. If the question mentions any time period, resolve it to explicit YYYY-MM-DD dates and pass filters[start] and filters[end] as well.",
         "operationId": "listEvents",
         "parameters": [
           {
@@ -58,7 +58,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": [
@@ -169,7 +169,7 @@
       "get": {
         "tags": ["Calendar"],
         "summary": "List all events in a given users calendar",
-        "description": "Returns all events in the user's calendar. Supports filtering, pagination, and custom property selection.",
+        "description": "Returns events from the user's calendar. Without filters[start]/filters[end] only events between 100 days in the past and 365 days in the future are returned. To bound the response size, send sync-token= (empty) together with nresults=20; the response then carries a more-results flag and a sync-token for the next chunk. If the question mentions any time period, resolve it to explicit YYYY-MM-DD dates and pass filters[start] and filters[end] as well.",
         "operationId": "listUserEvents",
         "parameters": [
           {
@@ -199,7 +199,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": ["application/json", "application/pretty+json"]
@@ -319,7 +319,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": ["application/json", "application/pretty+json"]
@@ -457,7 +457,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": ["application/json"]
@@ -536,25 +536,27 @@
         "schema": {
           "type": "integer"
         },
-        "description": "Limit number of responses (only for sync-collection)"
+        "description": "Limit the number of events returned. Only honored together with the sync-token parameter: send sync-token= (empty) plus nresults=N to receive at most N events, a \"more-results\": true flag when further events exist, and a sync-token to request the next chunk. Sent on its own, nresults has no effect."
       },
       "filters_start": {
         "name": "filters[start]",
         "in": "query",
         "required": false,
         "schema": {
-          "type": "datetime"
+          "type": "string",
+          "format": "date"
         },
-        "description": "Start date of search. Example: filters[start]=2026-01-01"
+        "description": "Only return entries overlapping this start date, as YYYY-MM-DD (a full ISO 8601 date-time is also accepted). REQUIRED whenever the question refers to a time period: resolve phrases like 'this week', 'today' or 'next month' to explicit dates and pass them. Example: filters[start]=2026-01-01"
       },
       "filters_end": {
         "name": "filters[end]",
         "in": "query",
         "required": false,
         "schema": {
-          "type": "datetime"
+          "type": "string",
+          "format": "date"
         },
-        "description": "End date of search. Example: filters[start]=2026-02-01"
+        "description": "Only return entries overlapping this end date, as YYYY-MM-DD (a full ISO 8601 date-time is also accepted). Pass together with filters[start] for any time-bounded question. Example: filters[end]=2026-02-01"
       },
       "filters_search": {
         "name": "filters[search]",
@@ -563,7 +565,7 @@
         "schema": {
           "type": "string"
         },
-        "description": "Search pattern. Example: filters[search]=something"
+        "description": "Free-text pattern searched over event title, description and location. Cannot be combined with filters[linked]. Example: filters[search]=standup"
       },
       "filters_linked": {
         "name": "filters[linked]",

--- a/doc/openapi/calendar.json
+++ b/doc/openapi/calendar.json
@@ -89,7 +89,9 @@
         }
       },
       "post": {
-        "tags": ["Calendar"],
+        "tags": [
+          "Calendar"
+        ],
         "summary": "Create a new event for the current user",
         "description": "Adds a new event to the calendar. The Location header in the response gives the URL of the new resource. Use `Prefer: return=representation` to get the full event in the response.",
         "operationId": "createEvent",
@@ -100,7 +102,9 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["application/json"]
+              "enum": [
+                "application/json"
+              ]
             }
           },
           {
@@ -109,7 +113,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["return=representation"]
+              "enum": [
+                "return=representation"
+              ]
             },
             "description": "Request the server to return the full representation of the created event"
           }
@@ -167,7 +173,9 @@
     },
     "/{username}/calendar/": {
       "get": {
-        "tags": ["Calendar"],
+        "tags": [
+          "Calendar"
+        ],
         "summary": "List all events in a given users calendar",
         "description": "Returns events from the user's calendar. Without filters[start]/filters[end] only events between 100 days in the past and 365 days in the future are returned. To bound the response size, send sync-token= (empty) together with nresults=20; the response then carries a more-results flag and a sync-token for the next chunk. If the question mentions any time period, resolve it to explicit YYYY-MM-DD dates and pass filters[start] and filters[end] as well.",
         "operationId": "listUserEvents",
@@ -202,7 +210,10 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["application/json", "application/pretty+json"]
+              "enum": [
+                "application/json",
+                "application/pretty+json"
+              ]
             },
             "description": "Accept header for JSON or pretty-printed JSON"
           }
@@ -227,7 +238,9 @@
         }
       },
       "post": {
-        "tags": ["Calendar"],
+        "tags": [
+          "Calendar"
+        ],
         "summary": "Create a new event for the given user",
         "description": "Adds a new event to the calendar. The Location header in the response gives the URL of the new resource. Use `Prefer: return=representation` to get the full event in the response.",
         "operationId": "createUserEvent",
@@ -241,7 +254,9 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["application/json"]
+              "enum": [
+                "application/json"
+              ]
             }
           },
           {
@@ -250,7 +265,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["return=representation"]
+              "enum": [
+                "return=representation"
+              ]
             },
             "description": "Request the server to return the full representation of the created event"
           }
@@ -308,7 +325,9 @@
     },
     "/calendar/{id}": {
       "get": {
-        "tags": ["Calendar"],
+        "tags": [
+          "Calendar"
+        ],
         "summary": "Get a single event",
         "description": "Retrieves a single event by ID.",
         "operationId": "getEvent",
@@ -322,7 +341,10 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["application/json", "application/pretty+json"]
+              "enum": [
+                "application/json",
+                "application/pretty+json"
+              ]
             }
           }
         ],
@@ -346,7 +368,9 @@
         }
       },
       "put": {
-        "tags": ["Calendar"],
+        "tags": [
+          "Calendar"
+        ],
         "summary": "Replace an event",
         "description": "Replaces all attributes of an event. Requires all attributes to be specified. If the ID is a UID, it will update the existing event or create a new one if it does not exist.",
         "operationId": "replaceEvent",
@@ -360,7 +384,9 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["application/json"]
+              "enum": [
+                "application/json"
+              ]
             }
           }
         ],
@@ -402,7 +428,9 @@
         }
       },
       "patch": {
-        "tags": ["Calendar"],
+        "tags": [
+          "Calendar"
+        ],
         "summary": "Partially update an event",
         "description": "Updates only the specified attributes of an event.",
         "operationId": "updateEvent",
@@ -416,7 +444,9 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["application/json"]
+              "enum": [
+                "application/json"
+              ]
             }
           }
         ],
@@ -446,7 +476,9 @@
         }
       },
       "delete": {
-        "tags": ["Calendar"],
+        "tags": [
+          "Calendar"
+        ],
         "summary": "Delete an event",
         "description": "Deletes an event by ID.",
         "operationId": "deleteEvent",
@@ -460,7 +492,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["application/json"]
+              "enum": [
+                "application/json"
+              ]
             },
             "description": "Accept header is required to avoid 404 Not Found (URL does not end with .ics)"
           }
@@ -474,6 +508,57 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/calendar/count": {
+      "get": {
+        "tags": [
+          "Calendar"
+        ],
+        "summary": "Count calendar events",
+        "description": "Returns ONLY the number of calendar events matching the filters, as {\"total\": <n>}. Use this to answer \"how many ...\" questions instead of listing entries: it accepts the same filters[...] parameters as the listing, but transfers no entries at all, so it works on collections of any size.",
+        "operationId": "countEvents",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/filters_start"
+          },
+          {
+            "$ref": "#/components/parameters/filters_end"
+          },
+          {
+            "$ref": "#/components/parameters/filters_search"
+          },
+          {
+            "$ref": "#/components/parameters/filters_linked"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Number of matching entries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "total": {
+                      "type": "integer",
+                      "description": "number of matching entries"
+                    }
+                  },
+                  "required": [
+                    "total"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid filter"
+          },
+          "401": {
+            "description": "Unauthorized"
           }
         }
       }
@@ -580,11 +665,20 @@
     "schemas": {
       "Event": {
         "type": "object",
-        "required": ["@type", "prodId", "uid", "title", "start", "duration"],
+        "required": [
+          "@type",
+          "prodId",
+          "uid",
+          "title",
+          "start",
+          "duration"
+        ],
         "properties": {
           "@type": {
             "type": "string",
-            "enum": ["Event"],
+            "enum": [
+              "Event"
+            ],
             "description": "Type of the resource (always 'Event')"
           },
           "prodId": {
@@ -679,7 +773,11 @@
           },
           "status": {
             "type": "string",
-            "enum": ["tentative", "confirmed", "cancelled"],
+            "enum": [
+              "tentative",
+              "confirmed",
+              "cancelled"
+            ],
             "description": "Status of the event"
           },
           "priority": {
@@ -688,12 +786,21 @@
           },
           "privacy": {
             "type": "string",
-            "enum": ["public", "private", "confidential"],
+            "enum": [
+              "public",
+              "private",
+              "confidential"
+            ],
             "description": "Privacy level of the event"
           },
           "freeBusyStatus": {
             "type": "string",
-            "enum": ["free", "busy", "busy-unavailable", "busy-tentative"],
+            "enum": [
+              "free",
+              "busy",
+              "busy-unavailable",
+              "busy-tentative"
+            ],
             "description": "Free/busy status of the event"
           },
           "description": {
@@ -733,14 +840,22 @@
           },
           "status": {
             "type": "string",
-            "enum": ["tentative", "confirmed", "cancelled"]
+            "enum": [
+              "tentative",
+              "confirmed",
+              "cancelled"
+            ]
           },
           "priority": {
             "type": "integer"
           },
           "privacy": {
             "type": "string",
-            "enum": ["public", "private", "confidential"]
+            "enum": [
+              "public",
+              "private",
+              "confidential"
+            ]
           },
           "alerts": {
             "type": "object",
@@ -759,15 +874,25 @@
       },
       "RecurrenceRule": {
         "type": "object",
-        "required": ["@type", "frequency"],
+        "required": [
+          "@type",
+          "frequency"
+        ],
         "properties": {
           "@type": {
             "type": "string",
-            "enum": ["RecurrenceRule"]
+            "enum": [
+              "RecurrenceRule"
+            ]
           },
           "frequency": {
             "type": "string",
-            "enum": ["daily", "weekly", "monthly", "yearly"]
+            "enum": [
+              "daily",
+              "weekly",
+              "monthly",
+              "yearly"
+            ]
           },
           "until": {
             "type": "string",
@@ -783,11 +908,16 @@
       },
       "NDay": {
         "type": "object",
-        "required": ["@type", "day"],
+        "required": [
+          "@type",
+          "day"
+        ],
         "properties": {
           "@type": {
             "type": "string",
-            "enum": ["NDay"]
+            "enum": [
+              "NDay"
+            ]
           },
           "day": {
             "type": "string",
@@ -797,11 +927,20 @@
       },
       "Participant": {
         "type": "object",
-        "required": ["@type", "name", "email", "kind", "roles", "participationStatus"],
+        "required": [
+          "@type",
+          "name",
+          "email",
+          "kind",
+          "roles",
+          "participationStatus"
+        ],
         "properties": {
           "@type": {
             "type": "string",
-            "enum": ["Participant"]
+            "enum": [
+              "Participant"
+            ]
           },
           "name": {
             "type": "string"
@@ -812,7 +951,10 @@
           },
           "kind": {
             "type": "string",
-            "enum": ["individual", "group"]
+            "enum": [
+              "individual",
+              "group"
+            ]
           },
           "roles": {
             "type": "object",
@@ -830,17 +972,30 @@
           },
           "participationStatus": {
             "type": "string",
-            "enum": ["needs-action", "accepted", "declined", "tentative", "delegated", "completed", "in-process"]
+            "enum": [
+              "needs-action",
+              "accepted",
+              "declined",
+              "tentative",
+              "delegated",
+              "completed",
+              "in-process"
+            ]
           }
         }
       },
       "Alert": {
         "type": "object",
-        "required": ["@type", "trigger"],
+        "required": [
+          "@type",
+          "trigger"
+        ],
         "properties": {
           "@type": {
             "type": "string",
-            "enum": ["Alert"]
+            "enum": [
+              "Alert"
+            ]
           },
           "trigger": {
             "$ref": "#/components/schemas/OffsetTrigger"
@@ -849,11 +1004,16 @@
       },
       "OffsetTrigger": {
         "type": "object",
-        "required": ["@type", "offset"],
+        "required": [
+          "@type",
+          "offset"
+        ],
         "properties": {
           "@type": {
             "type": "string",
-            "enum": ["OffsetTrigger"]
+            "enum": [
+              "OffsetTrigger"
+            ]
           },
           "offset": {
             "type": "integer",

--- a/doc/openapi/infolog.json
+++ b/doc/openapi/infolog.json
@@ -27,7 +27,9 @@
   "paths": {
     "/infolog/": {
       "get": {
-        "tags": ["InfoLog"],
+        "tags": [
+          "InfoLog"
+        ],
         "summary": "List all infolog entries",
         "description": "Returns infolog entries (tasks, notes, calls, etc.) for the user, most recently modified first. filters[start]/filters[end] match entries whose start/due date overlaps the range. To bound the response size, send sync-token= (empty) together with nresults=20; the response then carries a more-results flag and a sync-token for the next chunk. If the question mentions any time period, resolve it to explicit YYYY-MM-DD dates and pass filters[start] and filters[end] as well.",
         "operationId": "listTasks",
@@ -90,7 +92,9 @@
         }
       },
       "post": {
-        "tags": ["InfoLog"],
+        "tags": [
+          "InfoLog"
+        ],
         "summary": "Create a new infolog entry for the current user",
         "description": "Adds a new infolog entry (task, note, call, etc.) to the collection. The Location header in the response gives the URL of the new resource.",
         "operationId": "createTask",
@@ -101,7 +105,9 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["application/json"]
+              "enum": [
+                "application/json"
+              ]
             }
           }
         ],
@@ -146,7 +152,9 @@
     },
     "/{username}/infolog/": {
       "get": {
-        "tags": ["InfoLog"],
+        "tags": [
+          "InfoLog"
+        ],
         "summary": "List all infolog entries of a given user",
         "description": "Returns infolog entries (tasks, notes, calls, etc.) for the given user, most recently modified first. filters[start]/filters[end] match entries whose start/due date overlaps the range. To bound the response size, send sync-token= (empty) together with nresults=20; the response then carries a more-results flag and a sync-token for the next chunk. If the question mentions any time period, resolve it to explicit YYYY-MM-DD dates and pass filters[start] and filters[end] as well.",
         "operationId": "listUserTasks",
@@ -184,7 +192,10 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["application/json", "application/pretty+json"]
+              "enum": [
+                "application/json",
+                "application/pretty+json"
+              ]
             },
             "description": "Accept header for JSON or pretty-printed JSON"
           }
@@ -209,7 +220,9 @@
         }
       },
       "post": {
-        "tags": ["InfoLog"],
+        "tags": [
+          "InfoLog"
+        ],
         "summary": "Create a new infolog entry for the given user",
         "description": "Adds a new infolog entry (task, note, call, etc.) to the collection. The Location header in the response gives the URL of the new resource.",
         "operationId": "createUserTask",
@@ -223,7 +236,9 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["application/json"]
+              "enum": [
+                "application/json"
+              ]
             }
           }
         ],
@@ -268,7 +283,9 @@
     },
     "/infolog/{id}": {
       "get": {
-        "tags": ["InfoLog"],
+        "tags": [
+          "InfoLog"
+        ],
         "summary": "Get a single infolog entry",
         "description": "Retrieves a single infolog entry by ID.",
         "operationId": "getTask",
@@ -282,7 +299,10 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["application/json","application/pretty+json"]
+              "enum": [
+                "application/json",
+                "application/pretty+json"
+              ]
             },
             "description": "Accept header for JSON or pretty-printed JSON"
           }
@@ -307,7 +327,9 @@
         }
       },
       "put": {
-        "tags": ["InfoLog"],
+        "tags": [
+          "InfoLog"
+        ],
         "summary": "Replace an infolog entry",
         "description": "Replaces all attributes of an infolog entry. Requires all attributes to be specified.",
         "operationId": "replaceTask",
@@ -321,7 +343,9 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["application/json"]
+              "enum": [
+                "application/json"
+              ]
             }
           }
         ],
@@ -351,7 +375,9 @@
         }
       },
       "patch": {
-        "tags": ["InfoLog"],
+        "tags": [
+          "InfoLog"
+        ],
         "summary": "Partially update an infolog entry",
         "description": "Updates only the specified attributes of an infolog entry.",
         "operationId": "updateTask",
@@ -365,7 +391,9 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["application/json"]
+              "enum": [
+                "application/json"
+              ]
             }
           }
         ],
@@ -395,7 +423,9 @@
         }
       },
       "delete": {
-        "tags": ["InfoLog"],
+        "tags": [
+          "InfoLog"
+        ],
         "summary": "Delete an infolog entry",
         "description": "Deletes an infolog entry by ID.",
         "operationId": "deleteTask",
@@ -413,6 +443,60 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/infolog/count": {
+      "get": {
+        "tags": [
+          "InfoLog"
+        ],
+        "summary": "Count InfoLog entries (tasks, notes, calls)",
+        "description": "Returns ONLY the number of InfoLog entries (tasks, notes, calls) matching the filters, as {\"total\": <n>}. Use this to answer \"how many ...\" questions instead of listing entries: it accepts the same filters[...] parameters as the listing, but transfers no entries at all, so it works on collections of any size.",
+        "operationId": "countTasks",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/filters_order"
+          },
+          {
+            "$ref": "#/components/parameters/filters_start"
+          },
+          {
+            "$ref": "#/components/parameters/filters_end"
+          },
+          {
+            "$ref": "#/components/parameters/filters_search"
+          },
+          {
+            "$ref": "#/components/parameters/filters_linked"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Number of matching entries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "total": {
+                      "type": "integer",
+                      "description": "number of matching entries"
+                    }
+                  },
+                  "required": [
+                    "total"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid filter"
+          },
+          "401": {
+            "description": "Unauthorized"
           }
         }
       }
@@ -528,11 +612,17 @@
     "schemas": {
       "Task": {
         "type": "object",
-        "required": ["@type", "title", "type"],
+        "required": [
+          "@type",
+          "title",
+          "type"
+        ],
         "properties": {
           "@type": {
             "type": "string",
-            "enum": ["Task"],
+            "enum": [
+              "Task"
+            ],
             "description": "Type of the resource (always 'Task')"
           },
           "id": {
@@ -545,7 +635,14 @@
           },
           "type": {
             "type": "string",
-            "enum": ["note", "task", "call", "mail", "file", "message"],
+            "enum": [
+              "note",
+              "task",
+              "call",
+              "mail",
+              "file",
+              "message"
+            ],
             "description": "Type of the infolog entry (note, task, call, etc.)"
           },
           "description": {
@@ -564,7 +661,11 @@
           },
           "status": {
             "type": "string",
-            "enum": ["tentative", "confirmed", "cancelled"],
+            "enum": [
+              "tentative",
+              "confirmed",
+              "cancelled"
+            ],
             "readOnly": true,
             "description": "Stock JSCalendar status: 'tentative' (InfoLog 'offer'), 'cancelled' (InfoLog 'deleted'/'cancelled'), 'confirmed' otherwise. Read-only / ignored on write, as it does not reflect InfoLog's real status - use 'progress' and/or 'egroupware.org:status' to change it"
           },

--- a/doc/openapi/infolog.json
+++ b/doc/openapi/infolog.json
@@ -29,7 +29,7 @@
       "get": {
         "tags": ["InfoLog"],
         "summary": "List all infolog entries",
-        "description": "Returns all infolog entries (tasks, notes, calls, etc.) for the user. Supports filtering, pagination, and custom property selection.",
+        "description": "Returns infolog entries (tasks, notes, calls, etc.) for the user, most recently modified first. filters[start]/filters[end] match entries whose start/due date overlaps the range. To bound the response size, send sync-token= (empty) together with nresults=20; the response then carries a more-results flag and a sync-token for the next chunk. If the question mentions any time period, resolve it to explicit YYYY-MM-DD dates and pass filters[start] and filters[end] as well.",
         "operationId": "listTasks",
         "parameters": [
           {
@@ -40,6 +40,9 @@
           },
           {
             "$ref": "#/components/parameters/nresults"
+          },
+          {
+            "$ref": "#/components/parameters/filters_order"
           },
           {
             "$ref": "#/components/parameters/filters_start"
@@ -56,7 +59,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": [
@@ -145,7 +148,7 @@
       "get": {
         "tags": ["InfoLog"],
         "summary": "List all infolog entries of a given user",
-        "description": "Returns all infolog entries (tasks, notes, calls, etc.) for the given user. Supports filtering, pagination, and custom property selection.",
+        "description": "Returns infolog entries (tasks, notes, calls, etc.) for the given user, most recently modified first. filters[start]/filters[end] match entries whose start/due date overlaps the range. To bound the response size, send sync-token= (empty) together with nresults=20; the response then carries a more-results flag and a sync-token for the next chunk. If the question mentions any time period, resolve it to explicit YYYY-MM-DD dates and pass filters[start] and filters[end] as well.",
         "operationId": "listUserTasks",
         "parameters": [
           {
@@ -159,6 +162,9 @@
           },
           {
             "$ref": "#/components/parameters/nresults"
+          },
+          {
+            "$ref": "#/components/parameters/filters_order"
           },
           {
             "$ref": "#/components/parameters/filters_start"
@@ -175,7 +181,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": ["application/json", "application/pretty+json"]
@@ -273,7 +279,7 @@
           {
             "name": "Accept",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "enum": ["application/json","application/pretty+json"]
@@ -469,25 +475,36 @@
         "schema": {
           "type": "integer"
         },
-        "description": "Limit number of responses (only for sync-collection)"
+        "description": "Limit the number of entries returned. Only honored together with the sync-token parameter: send sync-token= (empty) plus nresults=N to receive at most N entries, a \"more-results\": true flag when further entries exist, and a sync-token to request the next chunk. Sent on its own, nresults has no effect."
       },
       "filters_start": {
         "name": "filters[start]",
         "in": "query",
         "required": false,
         "schema": {
-          "type": "datetime"
+          "type": "string",
+          "format": "date"
         },
-        "description": "Start date of search. Example: filters[start]=2026-01-01"
+        "description": "Only return entries overlapping this start date, as YYYY-MM-DD (a full ISO 8601 date-time is also accepted). REQUIRED whenever the question refers to a time period: resolve phrases like 'this week', 'today' or 'next month' to explicit dates and pass them. Example: filters[start]=2026-01-01"
       },
       "filters_end": {
         "name": "filters[end]",
         "in": "query",
         "required": false,
         "schema": {
-          "type": "datetime"
+          "type": "string",
+          "format": "date"
         },
-        "description": "End date of search. Example: filters[start]=2026-02-01"
+        "description": "Only return entries overlapping this end date, as YYYY-MM-DD (a full ISO 8601 date-time is also accepted). Pass together with filters[start] for any time-bounded question. Example: filters[end]=2026-02-01"
+      },
+      "filters_order": {
+        "name": "filters[order]",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Sort order as '<db-column>' optionally followed by ' ASC' or ' DESC'. Defaults to 'info_datemodified DESC' (newest first). Example: filters[order]=info_enddate ASC"
       },
       "filters_search": {
         "name": "filters[search]",

--- a/doc/openapi/projectmanager.json
+++ b/doc/openapi/projectmanager.json
@@ -1,0 +1,282 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "EGroupware ProjectManager REST API",
+    "version": "1.0.0",
+    "description": "Read and count projects of the EGroupware ProjectManager application."
+  },
+  "paths": {
+    "/projectmanager/": {
+      "get": {
+        "tags": [
+          "ProjectManager"
+        ],
+        "operationId": "listProjects",
+        "summary": "List all projects the current user has access to",
+        "description": "Returns projects of the current user. Without sync-token/nresults the number of projects returned is limited by the server configuration; the response carries \"total\" with the number of matching projects and \"more-results\": true when further projects exist. To count projects use countProjects instead of listing them.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/props"
+          },
+          {
+            "$ref": "#/components/parameters/syncToken"
+          },
+          {
+            "$ref": "#/components/parameters/nresults"
+          },
+          {
+            "$ref": "#/components/parameters/filters_start"
+          },
+          {
+            "$ref": "#/components/parameters/filters_end"
+          },
+          {
+            "$ref": "#/components/parameters/filters_order"
+          },
+          {
+            "$ref": "#/components/parameters/filters_search"
+          },
+          {
+            "$ref": "#/components/parameters/filters_linked"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "application/json",
+                "application/pretty+json"
+              ]
+            },
+            "description": "Accept header for JSON or pretty-printed JSON"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of projects",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "responses": {
+                      "type": "object",
+                      "description": "path => project"
+                    },
+                    "total": {
+                      "type": "integer",
+                      "description": "number of matching projects"
+                    },
+                    "more-results": {
+                      "type": "boolean",
+                      "description": "further projects exist"
+                    },
+                    "sync-token": {
+                      "type": "string",
+                      "description": "token to request the next chunk"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid filter"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/projectmanager/count": {
+      "get": {
+        "tags": [
+          "ProjectManager"
+        ],
+        "operationId": "countProjects",
+        "summary": "Count projects",
+        "description": "Returns ONLY the number of projects matching the filters, as {\"total\": <n>}. Use this to answer \"how many ...\" questions instead of listing entries: it accepts the same filters[...] parameters as the listing, but transfers no projects at all, so it works on collections of any size. Combine with filters[start] and filters[end] for a time period.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/filters_start"
+          },
+          {
+            "$ref": "#/components/parameters/filters_end"
+          },
+          {
+            "$ref": "#/components/parameters/filters_search"
+          },
+          {
+            "$ref": "#/components/parameters/filters_linked"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Number of matching projects",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "total": {
+                      "type": "integer",
+                      "description": "number of matching projects"
+                    }
+                  },
+                  "required": [
+                    "total"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid filter"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/projectmanager/{id}": {
+      "get": {
+        "tags": [
+          "ProjectManager"
+        ],
+        "operationId": "getProject",
+        "summary": "Retrieve a single project",
+        "description": "Returns one project by its numerical id or UID.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "application/json",
+                "application/pretty+json"
+              ]
+            },
+            "description": "Accept header for JSON or pretty-printed JSON"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The project",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Project not found"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "id": {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Numerical project-id or its UID"
+      },
+      "props": {
+        "name": "props[]",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "description": "Limit the returned properties, e.g. props[]=pm_title. Omit to get the full project."
+      },
+      "syncToken": {
+        "name": "sync-token",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Send empty to start a bounded listing; the response returns a sync-token to request the next chunk together with nresults."
+      },
+      "nresults": {
+        "name": "nresults",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer"
+        },
+        "description": "Maximum number of projects to return. Only evaluated together with sync-token: send sync-token= (empty) plus nresults=N to get at most N projects, a \"more-results\": true flag when further projects exist, and a sync-token for the next chunk."
+      },
+      "filters_start": {
+        "name": "filters[start]",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "date"
+        },
+        "description": "Only return projects created on or after this date (pm_created), as YYYY-MM-DD. REQUIRED whenever the question refers to a time period: resolve phrases like 'this quarter' or 'the last 3 months' to explicit dates. Example: filters[start]=2026-01-01"
+      },
+      "filters_end": {
+        "name": "filters[end]",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "date"
+        },
+        "description": "Only return projects created on or before this date (pm_created), as YYYY-MM-DD. A bare date covers the whole day. Example: filters[end]=2026-03-31"
+      },
+      "filters_order": {
+        "name": "filters[order]",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Sort order as '<db-column>' optionally followed by ' ASC' or ' DESC'. Default is pm_created ASC. An unknown column is rejected with 400 and a list of the valid ones."
+      },
+      "filters_search": {
+        "name": "filters[search]",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Free-text pattern searched over the project number, title and description. Example: filters[search]=migration"
+      },
+      "filters_linked": {
+        "name": "filters[linked]",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Only projects linked to the given entry, as '<app-name>:<numeric-id>'. Example: filters[linked]=infolog:123"
+      }
+    }
+  }
+}

--- a/doc/openapi/smallpart.json
+++ b/doc/openapi/smallpart.json
@@ -467,7 +467,7 @@
       },
       "post": {
         "tags": ["Materials"],
-        "operationId": "addAttachment",
+        "operationId": "addMaterialAttachment",
         "summary": "Add an attachment to a material",
         "description": "Redirects to the underlying WebDAV URL to actually upload the file content.",
         "responses": {

--- a/doc/openapi/timesheet.json
+++ b/doc/openapi/timesheet.json
@@ -50,6 +50,15 @@
             "$ref": "#/components/parameters/filters_linked"
           },
           {
+            "$ref": "#/components/parameters/filters_start"
+          },
+          {
+            "$ref": "#/components/parameters/filters_end"
+          },
+          {
+            "$ref": "#/components/parameters/filters_order"
+          },
+          {
             "name": "Accept",
             "in": "header",
             "required": true,
@@ -498,6 +507,60 @@
           }
         }
       }
+    },
+    "/timesheet/count": {
+      "get": {
+        "tags": [
+          "Timesheet"
+        ],
+        "summary": "Count timesheet entries",
+        "description": "Returns ONLY the number of timesheet entries matching the filters, as {\"total\": <n>}. Use this to answer \"how many ...\" questions instead of listing entries: it accepts the same filters[...] parameters as the listing, but transfers no entries at all, so it works on collections of any size. Combine with filters[start] and filters[end] for a time period.",
+        "operationId": "countTimesheets",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/filters_search"
+          },
+          {
+            "$ref": "#/components/parameters/filters_linked"
+          },
+          {
+            "$ref": "#/components/parameters/filters_start"
+          },
+          {
+            "$ref": "#/components/parameters/filters_end"
+          },
+          {
+            "$ref": "#/components/parameters/filters_order"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Number of matching entries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "total": {
+                      "type": "integer",
+                      "description": "number of matching entries"
+                    }
+                  },
+                  "required": [
+                    "total"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid filter"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -576,6 +639,35 @@
           "type": "string"
         },
         "description": "Search entries from other apps linked to the given one. Example: filters[linked]=<app-name>:<app-id>"
+      },
+      "filters_start": {
+        "name": "filters[start]",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "date"
+        },
+        "description": "Only return timesheet entries on or after this date, matched against the entry start-date (ts_start), as YYYY-MM-DD. REQUIRED whenever the question refers to a time period: resolve phrases like 'this week', 'last month' or 'the last 3 months' to explicit dates and pass them. Example: filters[start]=2026-01-01"
+      },
+      "filters_end": {
+        "name": "filters[end]",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "date"
+        },
+        "description": "Only return timesheet entries on or before this date, matched against the entry start-date (ts_start), as YYYY-MM-DD. A bare date covers the whole day. Pass together with filters[start] for any time-bounded question. Example: filters[end]=2026-03-31"
+      },
+      "filters_order": {
+        "name": "filters[order]",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Sort order as '<db-column>' optionally followed by ' ASC' or ' DESC'. Default is ts_start ASC. An unknown column is rejected with 400 and a list of the valid ones."
       }
     },
     "schemas": {

--- a/doc/openapi/tracker.json
+++ b/doc/openapi/tracker.json
@@ -20,33 +20,69 @@
     }
   ],
   "security": [
-    { "basicAuth": [] },
-    { "bearerAuth": [] }
+    {
+      "basicAuth": []
+    },
+    {
+      "bearerAuth": []
+    }
   ],
   "paths": {
     "/tracker/": {
       "get": {
-        "tags": ["Tracker"],
+        "tags": [
+          "Tracker"
+        ],
         "operationId": "listTickets",
         "summary": "List all tickets the current user has access to",
         "description": "Returns all tracker tickets accessible to the current user. Supports filtering by status, priority, queue, and assignee. Use 'filters[search]' for full-text search across summary and description.",
         "parameters": [
-          { "$ref": "#/components/parameters/props" },
-          { "$ref": "#/components/parameters/syncToken" },
-          { "$ref": "#/components/parameters/nresults" },
-          { "$ref": "#/components/parameters/filters_search" },
-          { "$ref": "#/components/parameters/filters_linked" },
-          { "$ref": "#/components/parameters/filters_status" },
-          { "$ref": "#/components/parameters/filters_priority" },
-          { "$ref": "#/components/parameters/filters_tracker" },
-          { "$ref": "#/components/parameters/filters_assigned" },
+          {
+            "$ref": "#/components/parameters/props"
+          },
+          {
+            "$ref": "#/components/parameters/syncToken"
+          },
+          {
+            "$ref": "#/components/parameters/nresults"
+          },
+          {
+            "$ref": "#/components/parameters/filters_search"
+          },
+          {
+            "$ref": "#/components/parameters/filters_linked"
+          },
+          {
+            "$ref": "#/components/parameters/filters_status"
+          },
+          {
+            "$ref": "#/components/parameters/filters_priority"
+          },
+          {
+            "$ref": "#/components/parameters/filters_tracker"
+          },
+          {
+            "$ref": "#/components/parameters/filters_assigned"
+          },
+          {
+            "$ref": "#/components/parameters/filters_start"
+          },
+          {
+            "$ref": "#/components/parameters/filters_end"
+          },
+          {
+            "$ref": "#/components/parameters/filters_order"
+          },
           {
             "name": "Accept",
             "in": "header",
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["application/json", "application/pretty+json"]
+              "enum": [
+                "application/json",
+                "application/pretty+json"
+              ]
             },
             "description": "Accept header for JSON or pretty-printed JSON"
           }
@@ -56,16 +92,24 @@
             "description": "A list of tickets",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/TicketCollection" }
+                "schema": {
+                  "$ref": "#/components/schemas/TicketCollection"
+                }
               }
             }
           },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" }
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
         }
       },
       "post": {
-        "tags": ["Tracker"],
+        "tags": [
+          "Tracker"
+        ],
         "operationId": "createTicket",
         "summary": "Create a new ticket for the current user",
         "description": "Creates a new tracker ticket. Only 'summary' is required. The ticket is created in the first queue the user has access to unless 'tracker' (queue ID) is specified.",
@@ -74,7 +118,12 @@
             "name": "Content-Type",
             "in": "header",
             "required": true,
-            "schema": { "type": "string", "enum": ["application/json"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "application/json"
+              ]
+            }
           },
           {
             "name": "Accept",
@@ -82,21 +131,31 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["application/json", "application/pretty+json"]
+              "enum": [
+                "application/json",
+                "application/pretty+json"
+              ]
             }
           },
           {
             "name": "Prefer",
             "in": "header",
             "required": false,
-            "schema": { "type": "string", "enum": ["return=representation"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "return=representation"
+              ]
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/Ticket" }
+              "schema": {
+                "$ref": "#/components/schemas/Ticket"
+              }
             }
           }
         },
@@ -106,48 +165,84 @@
             "headers": {
               "Location": {
                 "description": "URL of the new ticket, e.g. /egroupware/groupdav.php/admin/tracker/42",
-                "schema": { "type": "string", "format": "uri" }
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
               },
               "ETag": {
                 "description": "ETag of the new ticket",
-                "schema": { "type": "string" }
+                "schema": {
+                  "type": "string"
+                }
               }
             },
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Ticket" }
+                "schema": {
+                  "$ref": "#/components/schemas/Ticket"
+                }
               }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" }
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
         }
       }
     },
     "/{username}/tracker/": {
       "get": {
-        "tags": ["Tracker"],
+        "tags": [
+          "Tracker"
+        ],
         "operationId": "listUserTickets",
         "summary": "List all tickets for a given user",
         "description": "Returns all tracker tickets created by the specified user. Supports the same filters as the current-user endpoint.",
         "parameters": [
-          { "$ref": "#/components/parameters/username" },
-          { "$ref": "#/components/parameters/props" },
-          { "$ref": "#/components/parameters/syncToken" },
-          { "$ref": "#/components/parameters/nresults" },
-          { "$ref": "#/components/parameters/filters_search" },
-          { "$ref": "#/components/parameters/filters_linked" },
-          { "$ref": "#/components/parameters/filters_status" },
-          { "$ref": "#/components/parameters/filters_priority" },
-          { "$ref": "#/components/parameters/filters_tracker" },
-          { "$ref": "#/components/parameters/filters_assigned" },
+          {
+            "$ref": "#/components/parameters/username"
+          },
+          {
+            "$ref": "#/components/parameters/props"
+          },
+          {
+            "$ref": "#/components/parameters/syncToken"
+          },
+          {
+            "$ref": "#/components/parameters/nresults"
+          },
+          {
+            "$ref": "#/components/parameters/filters_search"
+          },
+          {
+            "$ref": "#/components/parameters/filters_linked"
+          },
+          {
+            "$ref": "#/components/parameters/filters_status"
+          },
+          {
+            "$ref": "#/components/parameters/filters_priority"
+          },
+          {
+            "$ref": "#/components/parameters/filters_tracker"
+          },
+          {
+            "$ref": "#/components/parameters/filters_assigned"
+          },
           {
             "name": "Accept",
             "in": "header",
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["application/json", "application/pretty+json"]
+              "enum": [
+                "application/json",
+                "application/pretty+json"
+              ]
             },
             "description": "Accept header for JSON or pretty-printed JSON"
           }
@@ -157,26 +252,41 @@
             "description": "A list of tickets",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/TicketCollection" }
+                "schema": {
+                  "$ref": "#/components/schemas/TicketCollection"
+                }
               }
             }
           },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" }
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
         }
       },
       "post": {
-        "tags": ["Tracker"],
+        "tags": [
+          "Tracker"
+        ],
         "operationId": "createUserTicket",
         "summary": "Create a new ticket for a specific user",
         "description": "Creates a new tracker ticket scoped to the given user's collection.",
         "parameters": [
-          { "$ref": "#/components/parameters/username" },
+          {
+            "$ref": "#/components/parameters/username"
+          },
           {
             "name": "Content-Type",
             "in": "header",
             "required": true,
-            "schema": { "type": "string", "enum": ["application/json"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "application/json"
+              ]
+            }
           },
           {
             "name": "Accept",
@@ -184,7 +294,10 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["application/json", "application/pretty+json"]
+              "enum": [
+                "application/json",
+                "application/pretty+json"
+              ]
             }
           }
         ],
@@ -192,7 +305,9 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/Ticket" }
+              "schema": {
+                "$ref": "#/components/schemas/Ticket"
+              }
             }
           }
         },
@@ -202,34 +317,50 @@
             "headers": {
               "Location": {
                 "description": "URL of the new ticket",
-                "schema": { "type": "string", "format": "uri" }
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
               },
               "ETag": {
                 "description": "ETag of the new ticket",
-                "schema": { "type": "string" }
+                "schema": {
+                  "type": "string"
+                }
               }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" }
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
         }
       }
     },
     "/tracker/{id}": {
       "get": {
-        "tags": ["Tracker"],
+        "tags": [
+          "Tracker"
+        ],
         "operationId": "getTicket",
         "summary": "Get a single ticket",
         "description": "Retrieves a single tracker ticket by its ID. Reply data is included in the optional 'replies' object keyed by reply ID when replies exist and are visible to the caller.",
         "parameters": [
-          { "$ref": "#/components/parameters/id" },
+          {
+            "$ref": "#/components/parameters/id"
+          },
           {
             "name": "Accept",
             "in": "header",
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["application/json", "application/pretty+json"]
+              "enum": [
+                "application/json",
+                "application/pretty+json"
+              ]
             }
           }
         ],
@@ -239,37 +370,56 @@
             "headers": {
               "ETag": {
                 "description": "ETag in format \"<id>:<modified-timestamp>\"",
-                "schema": { "type": "string" }
+                "schema": {
+                  "type": "string"
+                }
               }
             },
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Ticket" }
+                "schema": {
+                  "$ref": "#/components/schemas/Ticket"
+                }
               }
             }
           },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" }
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
         }
       },
       "put": {
-        "tags": ["Tracker"],
+        "tags": [
+          "Tracker"
+        ],
         "operationId": "replaceTicket",
         "summary": "Replace a ticket",
         "description": "Replaces all writable attributes of a ticket. 'summary' is required. Read-only fields (id, created, creator, modifier, modified, closed) are silently ignored. Fields the user lacks permission to change (e.g. completion for non-assignees) are also silently skipped.",
         "parameters": [
-          { "$ref": "#/components/parameters/id" },
+          {
+            "$ref": "#/components/parameters/id"
+          },
           {
             "name": "Content-Type",
             "in": "header",
             "required": true,
-            "schema": { "type": "string", "enum": ["application/json"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "application/json"
+              ]
+            }
           },
           {
             "name": "If-Match",
             "in": "header",
             "required": false,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "ETag for optimistic concurrency control. Returns 412 if the ticket was modified since this ETag."
           }
         ],
@@ -277,38 +427,59 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/Ticket" }
+              "schema": {
+                "$ref": "#/components/schemas/Ticket"
+              }
             }
           }
         },
         "responses": {
-          "204": { "description": "Ticket replaced" },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" },
+          "204": {
+            "description": "Ticket replaced"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
           "412": {
             "description": "Precondition Failed — ETag mismatch (concurrent edit detected)"
           }
         }
       },
       "patch": {
-        "tags": ["Tracker"],
+        "tags": [
+          "Tracker"
+        ],
         "operationId": "updateTicket",
         "summary": "Partially update a ticket",
         "description": "Updates only the fields present in the request body. All other fields keep their current values. Fields the user lacks permission to change are silently skipped (not rejected). 'description' is always read-only on PATCH (settable only at creation).",
         "parameters": [
-          { "$ref": "#/components/parameters/id" },
+          {
+            "$ref": "#/components/parameters/id"
+          },
           {
             "name": "Content-Type",
             "in": "header",
             "required": true,
-            "schema": { "type": "string", "enum": ["application/json"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "application/json"
+              ]
+            }
           },
           {
             "name": "If-Match",
             "in": "header",
             "required": false,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "ETag for optimistic concurrency control."
           }
         ],
@@ -321,58 +492,108 @@
                 "additionalProperties": true,
                 "description": "Partial ticket object — only the fields to update",
                 "properties": {
-                  "summary":    { "type": "string" },
-                  "status":     { "type": "string", "enum": ["Open", "Closed", "Pending", "Deleted"] },
-                  "priority":   { "type": "integer", "minimum": 1, "maximum": 9 },
-                  "completion": { "type": "integer", "minimum": 0, "maximum": 100 },
-                  "dueDate":    { "type": "string", "format": "date-time" },
-                  "assigned":   {
-                    "type": "array",
-                    "items": { "$ref": "#/components/schemas/AssignedUser" }
+                  "summary": {
+                    "type": "string"
                   },
-                  "private":    { "type": "boolean" }
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "Open",
+                      "Closed",
+                      "Pending",
+                      "Deleted"
+                    ]
+                  },
+                  "priority": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 9
+                  },
+                  "completion": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 100
+                  },
+                  "dueDate": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "assigned": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/AssignedUser"
+                    }
+                  },
+                  "private": {
+                    "type": "boolean"
+                  }
                 }
               }
             }
           }
         },
         "responses": {
-          "204": { "description": "Ticket partially updated" },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" }
+          "204": {
+            "description": "Ticket partially updated"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
         }
       },
       "delete": {
-        "tags": ["Tracker"],
+        "tags": [
+          "Tracker"
+        ],
         "operationId": "deleteTicket",
         "summary": "Delete a ticket",
         "description": "Deletes a tracker ticket by ID.",
         "parameters": [
-          { "$ref": "#/components/parameters/id" }
+          {
+            "$ref": "#/components/parameters/id"
+          }
         ],
         "responses": {
-          "204": { "description": "Ticket deleted" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" }
+          "204": {
+            "description": "Ticket deleted"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
         }
       }
     },
     "/tracker/{id}/replies/": {
       "get": {
-        "tags": ["Tracker Replies"],
+        "tags": [
+          "Tracker Replies"
+        ],
         "operationId": "listReplies",
         "summary": "List all replies for a ticket",
         "description": "Returns all visible replies for the specified tracker ticket as an object keyed by reply ID.",
         "parameters": [
-          { "$ref": "#/components/parameters/id" },
+          {
+            "$ref": "#/components/parameters/id"
+          },
           {
             "name": "Accept",
             "in": "header",
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["application/json", "application/pretty+json"]
+              "enum": [
+                "application/json",
+                "application/pretty+json"
+              ]
             }
           }
         ],
@@ -381,26 +602,41 @@
             "description": "A map of reply IDs to reply objects",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ReplyCollection" }
+                "schema": {
+                  "$ref": "#/components/schemas/ReplyCollection"
+                }
               }
             }
           },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" }
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
         }
       },
       "post": {
-        "tags": ["Tracker Replies"],
+        "tags": [
+          "Tracker Replies"
+        ],
         "operationId": "createReply",
         "summary": "Create a reply on a ticket",
         "description": "Adds a new reply/comment to the specified tracker ticket.",
         "parameters": [
-          { "$ref": "#/components/parameters/id" },
+          {
+            "$ref": "#/components/parameters/id"
+          },
           {
             "name": "Content-Type",
             "in": "header",
             "required": true,
-            "schema": { "type": "string", "enum": ["application/json"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "application/json"
+              ]
+            }
           },
           {
             "name": "Accept",
@@ -408,7 +644,10 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["application/json", "application/pretty+json"]
+              "enum": [
+                "application/json",
+                "application/pretty+json"
+              ]
             }
           }
         ],
@@ -416,7 +655,9 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/ReplyWrite" }
+              "schema": {
+                "$ref": "#/components/schemas/ReplyWrite"
+              }
             }
           }
         },
@@ -426,32 +667,50 @@
             "headers": {
               "Location": {
                 "description": "URL of the new reply, e.g. /egroupware/groupdav.php/admin/tracker/42/replies/101",
-                "schema": { "type": "string", "format": "uri" }
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
               }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" }
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
         }
       }
     },
     "/tracker/{id}/replies/{reply_id}": {
       "get": {
-        "tags": ["Tracker Replies"],
+        "tags": [
+          "Tracker Replies"
+        ],
         "operationId": "getReply",
         "summary": "Get a single reply",
         "description": "Retrieves a single reply/comment by ticket ID and reply ID.",
         "parameters": [
-          { "$ref": "#/components/parameters/id" },
-          { "$ref": "#/components/parameters/reply_id" },
+          {
+            "$ref": "#/components/parameters/id"
+          },
+          {
+            "$ref": "#/components/parameters/reply_id"
+          },
           {
             "name": "Accept",
             "in": "header",
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["application/json", "application/pretty+json"]
+              "enum": [
+                "application/json",
+                "application/pretty+json"
+              ]
             }
           }
         ],
@@ -460,87 +719,213 @@
             "description": "A single reply",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Reply" }
+                "schema": {
+                  "$ref": "#/components/schemas/Reply"
+                }
               }
             }
           },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" }
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
         }
       },
       "put": {
-        "tags": ["Tracker Replies"],
+        "tags": [
+          "Tracker Replies"
+        ],
         "operationId": "replaceReply",
         "summary": "Replace a reply",
         "description": "Fully replaces a reply. 'message' is required.",
         "parameters": [
-          { "$ref": "#/components/parameters/id" },
-          { "$ref": "#/components/parameters/reply_id" },
+          {
+            "$ref": "#/components/parameters/id"
+          },
+          {
+            "$ref": "#/components/parameters/reply_id"
+          },
           {
             "name": "Content-Type",
             "in": "header",
             "required": true,
-            "schema": { "type": "string", "enum": ["application/json"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "application/json"
+              ]
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/ReplyWrite" }
+              "schema": {
+                "$ref": "#/components/schemas/ReplyWrite"
+              }
             }
           }
         },
         "responses": {
-          "204": { "description": "Reply replaced" },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" }
+          "204": {
+            "description": "Reply replaced"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
         }
       },
       "patch": {
-        "tags": ["Tracker Replies"],
+        "tags": [
+          "Tracker Replies"
+        ],
         "operationId": "updateReply",
         "summary": "Partially update a reply",
         "description": "Updates only the supplied reply fields.",
         "parameters": [
-          { "$ref": "#/components/parameters/id" },
-          { "$ref": "#/components/parameters/reply_id" },
+          {
+            "$ref": "#/components/parameters/id"
+          },
+          {
+            "$ref": "#/components/parameters/reply_id"
+          },
           {
             "name": "Content-Type",
             "in": "header",
             "required": true,
-            "schema": { "type": "string", "enum": ["application/json"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "application/json"
+              ]
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/ReplyPatch" }
+              "schema": {
+                "$ref": "#/components/schemas/ReplyPatch"
+              }
             }
           }
         },
         "responses": {
-          "204": { "description": "Reply updated" },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" }
+          "204": {
+            "description": "Reply updated"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
         }
       },
       "delete": {
-        "tags": ["Tracker Replies"],
+        "tags": [
+          "Tracker Replies"
+        ],
         "operationId": "deleteReply",
         "summary": "Delete a reply",
         "description": "Deletes a reply/comment from the specified tracker ticket.",
         "parameters": [
-          { "$ref": "#/components/parameters/id" },
-          { "$ref": "#/components/parameters/reply_id" }
+          {
+            "$ref": "#/components/parameters/id"
+          },
+          {
+            "$ref": "#/components/parameters/reply_id"
+          }
         ],
         "responses": {
-          "204": { "description": "Reply deleted" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" }
+          "204": {
+            "description": "Reply deleted"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/tracker/count": {
+      "get": {
+        "tags": [
+          "Tracker"
+        ],
+        "summary": "Count tracker tickets",
+        "description": "Returns ONLY the number of tracker tickets matching the filters, as {\"total\": <n>}. Use this to answer \"how many ...\" questions instead of listing entries: it accepts the same filters[...] parameters as the listing, but transfers no entries at all, so it works on collections of any size. Combine with filters[start] and filters[end] for a time period.",
+        "operationId": "countTickets",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/filters_search"
+          },
+          {
+            "$ref": "#/components/parameters/filters_linked"
+          },
+          {
+            "$ref": "#/components/parameters/filters_status"
+          },
+          {
+            "$ref": "#/components/parameters/filters_priority"
+          },
+          {
+            "$ref": "#/components/parameters/filters_tracker"
+          },
+          {
+            "$ref": "#/components/parameters/filters_assigned"
+          },
+          {
+            "$ref": "#/components/parameters/filters_start"
+          },
+          {
+            "$ref": "#/components/parameters/filters_end"
+          },
+          {
+            "$ref": "#/components/parameters/filters_order"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Number of matching entries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "total": {
+                      "type": "integer",
+                      "description": "number of matching entries"
+                    }
+                  },
+                  "required": [
+                    "total"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid filter"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     }
@@ -561,11 +946,15 @@
     "schemas": {
       "Ticket": {
         "type": "object",
-        "required": ["summary"],
+        "required": [
+          "summary"
+        ],
         "properties": {
           "@type": {
             "type": "string",
-            "enum": ["Ticket"],
+            "enum": [
+              "Ticket"
+            ],
             "description": "Always 'Ticket'. Ignored on write.",
             "readOnly": true
           },
@@ -588,7 +977,12 @@
           },
           "status": {
             "type": "string",
-            "enum": ["Open", "Closed", "Pending", "Deleted"],
+            "enum": [
+              "Open",
+              "Closed",
+              "Pending",
+              "Deleted"
+            ],
             "description": "Ticket status. Custom per-queue statuses are also accepted and returned as their label string.",
             "default": "Open"
           },
@@ -659,7 +1053,9 @@
           },
           "assigned": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/AssignedUser" },
+            "items": {
+              "$ref": "#/components/schemas/AssignedUser"
+            },
             "description": "List of users assigned to this ticket."
           },
           "cc": {
@@ -705,7 +1101,9 @@
           "modified": "2026-05-25T11:30:00Z",
           "modifier": "admin",
           "assigned": [
-            { "uid": "urn:ietf:params:scim:schemas:core:2.0:User:john" }
+            {
+              "uid": "urn:ietf:params:scim:schemas:core:2.0:User:john"
+            }
           ],
           "group": "Admins",
           "replies": {
@@ -726,7 +1124,9 @@
         "properties": {
           "@type": {
             "type": "string",
-            "enum": ["Reply"],
+            "enum": [
+              "Reply"
+            ],
             "description": "Always 'Reply'.",
             "readOnly": true
           },
@@ -756,7 +1156,9 @@
             "default": false
           }
         },
-        "required": ["message"],
+        "required": [
+          "message"
+        ],
         "example": {
           "@type": "Reply",
           "id": 101,
@@ -768,7 +1170,9 @@
       },
       "ReplyWrite": {
         "type": "object",
-        "required": ["message"],
+        "required": [
+          "message"
+        ],
         "properties": {
           "message": {
             "type": "string",
@@ -804,7 +1208,9 @@
       },
       "AssignedUser": {
         "type": "object",
-        "required": ["uid"],
+        "required": [
+          "uid"
+        ],
         "properties": {
           "uid": {
             "type": "string",
@@ -822,8 +1228,12 @@
             "description": "Map of ticket paths to ticket objects (or null for deleted resources during sync).",
             "additionalProperties": {
               "oneOf": [
-                { "$ref": "#/components/schemas/Ticket" },
-                { "type": "null" }
+                {
+                  "$ref": "#/components/schemas/Ticket"
+                },
+                {
+                  "type": "null"
+                }
               ]
             },
             "example": {
@@ -873,28 +1283,39 @@
         "name": "username",
         "in": "path",
         "required": true,
-        "schema": { "type": "string" },
+        "schema": {
+          "type": "string"
+        },
         "description": "EGroupware username (e.g. 'admin'). Scopes the collection to that user's tickets."
       },
       "id": {
         "name": "id",
         "in": "path",
         "required": true,
-        "schema": { "type": "integer" },
+        "schema": {
+          "type": "integer"
+        },
         "description": "Numeric ticket ID"
       },
       "reply_id": {
         "name": "reply_id",
         "in": "path",
         "required": true,
-        "schema": { "type": "integer" },
+        "schema": {
+          "type": "integer"
+        },
         "description": "Numeric reply ID"
       },
       "props": {
         "name": "props[]",
         "in": "query",
         "required": false,
-        "schema": { "type": "array", "items": { "type": "string" } },
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "description": "DAV properties to return (e.g. props[]=getetag&props[]=displayname)",
         "style": "form",
         "explode": true
@@ -903,28 +1324,36 @@
         "name": "sync-token",
         "in": "query",
         "required": false,
-        "schema": { "type": "string" },
+        "schema": {
+          "type": "string"
+        },
         "description": "Sync token from a previous response to receive only changes since that point."
       },
       "nresults": {
         "name": "nresults",
         "in": "query",
         "required": false,
-        "schema": { "type": "integer" },
+        "schema": {
+          "type": "integer"
+        },
         "description": "Maximum number of tickets to return."
       },
       "filters_search": {
         "name": "filters[search]",
         "in": "query",
         "required": false,
-        "schema": { "type": "string" },
+        "schema": {
+          "type": "string"
+        },
         "description": "Full-text search across ticket summary and description. Example: filters[search]=mobile+login"
       },
       "filters_linked": {
         "name": "filters[linked]",
         "in": "query",
         "required": false,
-        "schema": { "type": "string" },
+        "schema": {
+          "type": "string"
+        },
         "description": "Return tickets linked to a record in another app. Format: '<app>:<id>'. Example: filters[linked]=infolog:5"
       },
       "filters_status": {
@@ -933,7 +1362,12 @@
         "required": false,
         "schema": {
           "type": "string",
-          "enum": ["Open", "Closed", "Pending", "Deleted"]
+          "enum": [
+            "Open",
+            "Closed",
+            "Pending",
+            "Deleted"
+          ]
         },
         "description": "Filter by ticket status. Custom queue statuses are also accepted."
       },
@@ -941,22 +1375,59 @@
         "name": "filters[priority]",
         "in": "query",
         "required": false,
-        "schema": { "type": "integer", "minimum": 1, "maximum": 9 },
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 9
+        },
         "description": "Filter by priority (1=lowest, 9=highest). Example: filters[priority]=9"
       },
       "filters_tracker": {
         "name": "filters[tracker]",
         "in": "query",
         "required": false,
-        "schema": { "type": "integer" },
+        "schema": {
+          "type": "integer"
+        },
         "description": "Filter by queue/tracker category ID. Example: filters[tracker]=8"
       },
       "filters_assigned": {
         "name": "filters[assigned]",
         "in": "query",
         "required": false,
-        "schema": { "type": "string" },
+        "schema": {
+          "type": "string"
+        },
         "description": "Filter by assigned user — accepts a login name or numeric account ID. Example: filters[assigned]=john"
+      },
+      "filters_start": {
+        "name": "filters[start]",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "date"
+        },
+        "description": "Only return tracker tickets on or after this date, matched against the creation date (tr_created), as YYYY-MM-DD. REQUIRED whenever the question refers to a time period: resolve phrases like 'this week', 'last month' or 'the last 3 months' to explicit dates and pass them. Example: filters[start]=2026-01-01"
+      },
+      "filters_end": {
+        "name": "filters[end]",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "date"
+        },
+        "description": "Only return tracker tickets on or before this date, matched against the creation date (tr_created), as YYYY-MM-DD. A bare date covers the whole day. Pass together with filters[start] for any time-bounded question. Example: filters[end]=2026-03-31"
+      },
+      "filters_order": {
+        "name": "filters[order]",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Sort order as '<db-column>' optionally followed by ' ASC' or ' DESC'. Default is tr_created ASC. An unknown column is rejected with 400 and a list of the valid ones."
       }
     },
     "responses": {
@@ -967,8 +1438,14 @@
             "schema": {
               "type": "object",
               "properties": {
-                "error": { "type": "integer", "example": 401 },
-                "message": { "type": "string", "example": "Unauthorized" }
+                "error": {
+                  "type": "integer",
+                  "example": 401
+                },
+                "message": {
+                  "type": "string",
+                  "example": "Unauthorized"
+                }
               }
             }
           }
@@ -981,8 +1458,14 @@
             "schema": {
               "type": "object",
               "properties": {
-                "error": { "type": "integer", "example": 404 },
-                "message": { "type": "string", "example": "Not Found" }
+                "error": {
+                  "type": "integer",
+                  "example": 404
+                },
+                "message": {
+                  "type": "string",
+                  "example": "Not Found"
+                }
               }
             }
           }
@@ -995,8 +1478,14 @@
             "schema": {
               "type": "object",
               "properties": {
-                "error": { "type": "integer", "example": 400 },
-                "message": { "type": "string", "example": "Invalid status 'InProgress'" }
+                "error": {
+                  "type": "integer",
+                  "example": 400
+                },
+                "message": {
+                  "type": "string",
+                  "example": "Invalid status 'InProgress'"
+                }
               }
             }
           }

--- a/infolog/inc/class.infolog_groupdav.inc.php
+++ b/infolog/inc/class.infolog_groupdav.inc.php
@@ -217,6 +217,8 @@ class infolog_groupdav extends Api\CalDAV\Handler
 			// callback to query sync-token, after propfind_callbacks / iterator is run and
 			// stored max. modification-time in $this->sync_collection_token
 			$files['sync-token'] = array($this, 'get_sync_collection_token');
+			// report the total to REST clients, it is queried anyway to determine more-results
+			$files['total'] = array($this, 'getTotal');
 			$files['sync-token-params'] = array($path, $user);
 
 			$this->sync_collection_token = $this->more_results = null;
@@ -358,6 +360,7 @@ class infolog_groupdav extends Api\CalDAV\Handler
 			// if $query[cols] is set, bo->search() returns an iterator, which might be empty, in which case we have to stop
 			(is_array($tasks) || $tasks->NumRows()))
 		{
+			$this->total = $this->bo->total;
 			if ($this->debug)
 			{
 				error_log(__METHOD__ . "(): called bo->search(" . json_encode($query) . ") returned ".(is_array($tasks) ? count($tasks) : $tasks->NumRows())." entries");
@@ -481,6 +484,25 @@ class infolog_groupdav extends Api\CalDAV\Handler
 						$time_ranges[] = $this->_time_range_filter($value['attrs']);
 					}
 					unset($json_filters[$key]);
+				}
+			}
+			foreach($json_filters as $name => $value)
+			{
+				switch($name)
+				{
+					case 'order':
+						$json_filters['order'] = $this->jsonOrderFilter($value);
+						break;
+					case 'search':
+					case 'filter':
+						break;      // handled by infolog_bo::search()
+					default:
+						if ($name[0] !== '#')
+						{
+							// reject an unknown filter with a helpful 400, instead of an SQL error
+							$this->assertFilterColumn($name, $name);
+						}
+						break;
 				}
 			}
 			$filters = $json_filters + $filters;    // + to allow overwriting default owner filter (BO ensures ACL!)

--- a/infolog/inc/class.infolog_groupdav.inc.php
+++ b/infolog/inc/class.infolog_groupdav.inc.php
@@ -467,7 +467,27 @@ class infolog_groupdav extends Api\CalDAV\Handler
 		// in case of JSON/REST API pass filters to report
 		if (Api\CalDAV::isJSON() && !empty($options['filters']) && is_array($options['filters']))
 		{
-			$filters = $options['filters'] + $filters;    // + to allow overwriting default owner filter (BO ensures ACL!)
+			// CalDAV::jsonIndex() turns filters[start]/filters[end] into a synthetic time-range
+			// element under an integer key. It has to go through _time_range_filter() to become a
+			// SQL fragment: merging it verbatim into the column filter yields "AND Array" and a 500.
+			$json_filters = $options['filters'];
+			$time_ranges = [];
+			foreach($json_filters as $key => $value)
+			{
+				if (!is_string($key))
+				{
+					if (is_array($value) && ($value['name'] ?? null) === 'time-range')
+					{
+						$time_ranges[] = $this->_time_range_filter($value['attrs']);
+					}
+					unset($json_filters[$key]);
+				}
+			}
+			$filters = $json_filters + $filters;    // + to allow overwriting default owner filter (BO ensures ACL!)
+			foreach($time_ranges as $time_range)
+			{
+				$filters[] = $time_range;
+			}
 		}
 		elseif ($options['filters'])
 		{
@@ -600,11 +620,11 @@ class infolog_groupdav extends Api\CalDAV\Handler
 		$to_or = $to_and = array();
  		if (!empty($attrs['start']))
  		{
- 			$start = (int)$this->vCalendar->_parseDateTime($attrs['start']);
+ 			$start = (int)Api\DateTime::to($this->vCalendar->_parseDateTime($attrs['start']), 'ts');
 		}
  		if (!empty($attrs['end']))
  		{
- 			$end = (int)$this->vCalendar->_parseDateTime($attrs['end']);
+ 			$end = (int)Api\DateTime::to($this->vCalendar->_parseDateTime($attrs['end']), 'ts');
 		}
 		elseif (empty($attrs['start']))
 		{
@@ -634,12 +654,14 @@ class infolog_groupdav extends Api\CalDAV\Handler
 			($end ? " AND info_enddate <= $end" : '');*/
 
 		// no startdate AND no enddate (2. half of rfc4791#section-9.9) --> use created and due dates instead
+		// info_datecompleted is nullable, so it needs COALESCE: "NULL > 0" and "NOT NULL > 0" are both
+		// NULL, which would make an entry without any date invisible to every time-range filter
 		$to_or[] = 'NOT info_startdate > 0 AND NOT info_enddate > 0 AND ('.
 			// we have a completed date
-			"info_datecompleted > 0".(isset($start) ? " AND ($start <= info_datecompleted OR $start <= info_created)" : '').
+			"COALESCE(info_datecompleted, 0) > 0".(isset($start) ? " AND ($start <= info_datecompleted OR $start <= info_created)" : '').
 				(isset($end) ? " AND (info_datecompleted <= $end OR info_created <= $end)" : '').' OR '.
 			// we have no completed date, but always a created date
- 			"NOT info_datecompleted > 0". (isset($end) ? " AND info_created < $end" : '').
+ 			"NOT COALESCE(info_datecompleted, 0) > 0". (isset($end) ? " AND info_created < $end" : '').
 		')';
 		$sql = '('.implode(' OR ', $to_or).')';
 		if ($this->debug > 1) error_log(__FILE__ . __METHOD__.'('.array2string($attrs).") time-range=$attrs[start]-$attrs[end] --> $sql");

--- a/timesheet/src/ApiHandler.php
+++ b/timesheet/src/ApiHandler.php
@@ -80,6 +80,8 @@ class ApiHandler extends Api\CalDAV\Handler
 			// callback to query sync-token, after propfind_callbacks / iterator is run and
 			// stored max. modification-time in $this->sync_collection_token
 			$files['sync-token'] = array($this, 'get_sync_collection_token');
+			// report the total to REST clients, it is queried anyway to determine more-results
+			$files['total'] = array($this, 'getTotal');
 			$files['sync-token-params'] = array($path, $user);
 
 			$this->sync_collection_token = $this->more_results = null;
@@ -171,6 +173,7 @@ class ApiHandler extends Api\CalDAV\Handler
 		for($chunk=0; ($timesheets =& $this->bo->search($search, '*', $order, '', '', False, 'AND',
 			[$inital_sync_token_offset+$chunk*self::CHUNK_SIZE, $nresults ?: self::CHUNK_SIZE], $filter)); ++$chunk)
 		{
+			$this->total = $this->bo->total;
 			// read custom-fields
 			if ($this->bo->customfields)
 			{
@@ -278,8 +281,21 @@ class ApiHandler extends Api\CalDAV\Handler
 		$cols = [];
 		foreach($filter as $name => $value)
 		{
+			// CalDAV::jsonIndex() appends filters[start] / filters[end] as a time-range under an integer key
+			if (!is_string($name))
+			{
+				if (is_array($value) && ($value['name'] ?? null) === 'time-range')
+				{
+					$cols[] = $this->jsonTimeRangeFilter($value['attrs'], 'ts_start');
+				}
+				continue;
+			}
 			switch($name)
 			{
+				case 'order':
+					$cols['order'] = $this->jsonOrderFilter($value);
+					break;
+
 				case 'search':
 					$cols = array_merge($cols, $this->bo->search2criteria($value));
 					break;
@@ -327,7 +343,9 @@ class ApiHandler extends Api\CalDAV\Handler
 					}
 					else
 					{
-						$cols['ts_'.$name] = $value;
+						// reject an unknown filter with a helpful 400, instead of an SQL error
+						$this->assertFilterColumn($column='ts_'.$name, $name);
+						$cols[$column] = $value;
 					}
 					break;
 			}


### PR DESCRIPTION
Four fixes on the REST/JSON side of `groupdav.php`. They were found together while
connecting the OpenAPI description to an OpenAPI tool client, but each stands alone.

## 1. `openapi.json` aborted, so no operation at all was served

`GET /groupdav.php/openapi.json` threw:

```
parameters /smallpart/{id} requires an unique operationId!
```

`OpenAPI::scan()` iterates every key of a path-item object and demands an `operationId`
from each. `doc/openapi/smallpart.json` (added in 5e1d62a2bf) is the first description to
use **path-level `parameters`**, which OpenAPI 3.x §4.8.9 defines as applying to all
operations of that path. The shared array was treated as an operation, and one bad artifact
aborts the *entire* specification — a consuming tool server then loads zero tools, with the
message visible only in the PHP error log.

- Only the eight HTTP methods are operations now (`self::HTTP_METHODS`); `parameters`,
  `summary`, `description`, `servers` and `$ref` are skipped.
- Path-level parameters are merged into each operation (`mergeParameters()`), operation-level
  entries winning for the same `name` + `in`, before the existing `$ref` inlining. Without the
  merge the seven smallpart paths lose `id` and `material_id` entirely.
- `links.json` (`POST /{app}/{id}/links/{filename}`) and `smallpart.json`
  (`POST /smallpart/{id}/{material_id}/attachments/`) both used `addAttachment`. The generic
  one keeps the name; smallpart's becomes `addMaterialAttachment`.
- Descriptions of apps that are **not installed** were served anyway — the guard only skipped
  apps the *user* lacked rights for. On an install without the `invoices` app, `invoices.json`
  still contributed 16 operations whose endpoints 404. `isAppSpecific()` decides from the paths
  themselves (at least one path below `/<app>`), keeping app-independent descriptions such as
  `links.json` (`/{app}/{id}/links/`) unconditional. The check is skipped when
  `$GLOBALS['egw_info']['apps']` is empty, so unauthenticated access is unchanged.

## 2. `calendar`: `filters[search]` and `filters[linked]` were silently ignored

`calendar_groupdav::_report_filters()` had no `Api\CalDAV::isJSON()` branch. REST filters
arrive as a plain `name => value` array rather than CalDAV XML elements, so every one of them
reached the `default:` arm and was discarded — `GET /calendar/?filters[search]=Standup`
returned the whole collection. New `jsonReportFilters()` handles the JSON shape, including the
synthetic `time-range` element `CalDAV::jsonIndex()` builds under an integer key.

`filters[linked]` uses `query['egw_cal.cal_id']`, not `sql_filter`, because
`calendar_bo::search()` overwrites `$params['sql_filter']` from its own second argument. It
accepts only one "query", so free-text `search` cannot be combined with `linked`; that pair
returns 400. An entry with no links yields `[0]` rather than an empty `IN ()`.

## 3. `infolog`: date filters returned HTTP 500, then matched nothing

Three defects stacked; fixing only the first leaves the filter silently useless.

**a.** The integer-keyed `time-range` element was merged verbatim into the column filter:

```
Invalid SQL: SELECT COUNT(*) FROM egw_infolog WHERE ( ... AND Array )
Unknown column 'Array' in 'WHERE' (1054)
```

Now routed through `_time_range_filter()`, as the CalDAV XML branch already did.

**b.** `_time_range_filter()` used `(int)$this->vCalendar->_parseDateTime(...)`.
`Horde_Icalendar::_parseDateTime()` builds its result with `DateTime::createFromFormat()` and
returns a **`DateTime` object** (or the input string if no format matched) — never an integer.
`(int)$object` is `1`, so every window produced identical SQL (`1 < info_enddate …`) and
identical results. Now converted via `Api\DateTime::to(..., 'ts')`.

This is **not REST-specific**: infolog `time-range` REPORTs over CalDAV compared against
epoch 1 too. These are the only two call sites casting the parser result; all calendar call
sites pass the object through, which is why calendar was unaffected.

**c.** `egw_infolog.info_datecompleted` is `bigint(20) NULL DEFAULT NULL`. The second half of
RFC 4791 §9.9 branches on `info_datecompleted > 0` / `NOT info_datecompleted > 0`, and in SQL
both are NULL when the column is NULL — so neither branch matches and an entry without any
date is invisible to every time-range filter. Both tests now use `COALESCE(info_datecompleted, 0)`.
`info_startdate` / `info_enddate` are `NOT NULL` and are left alone.

## 4. The table schema was echoed to REST/CalDAV clients

`Db::column_data_implode()` built its `InvalidSql` message from `print_r($array)` plus
`print_r($column_definitions)`, and `CalDAV::exception_handler()` returns exception messages to
the client. Any REST request naming a column that does not exist returned the complete table
definition — every column, type, precision and nullability:

```
GET /infolog/?filters[order]=DROP%20TABLE
→ 500 {"error":100,"message":"db::column_data_implode(' AND ',Array\n(\n    [order] => DROP TABLE\n)\n,'1',,<pre>Array\n(\n    [info_id] => Arr…"}
```

The arrays now go to `error_log()` with a flat list of the known column names; the client gets
one line. 3832 bytes → 35. Message text only, no control flow.

## OpenAPI description corrections

`calendar.json` and `infolog.json` declared `filters[start]` / `filters[end]` as
`"type": "datetime"`, which is not a JSON Schema type. Clients that derive a function schema
from the description copy it verbatim, so the parameters arrived unusable — the direct reason
date filters were never sent. Now `"type": "string"`, `"format": "date"`.

`Accept` is no longer `required`: it is `in: header`, and OpenAPI tool clients commonly forward
only `path` and `query` parameters, so a value was forced and then discarded. `nresults` now
spells out that it takes effect only together with `sync-token=`. `filters[order]` is documented
for infolog with its real default ordering.
