### PR TITLE
docs: fix typos in docker development and webcomponents docs

### DIFF
--- a/doc/docker/development/README.md
+++ b/doc/docker/development/README.md
@@ -1,6 +1,6 @@
-# EGroupware development enviroment as Docker container
+# EGroupware development environment as Docker container
 
-The container and docker-compose.yml file in this directory are the easiest way to get a full development enviroment for EGroupware.
+The container and docker-compose.yml file in this directory are the easiest way to get a full development environment for EGroupware.
 
 ### It defines and uses the following volumes:
 * sources: document root of the webserver, by default $PWD/sources subdirectory, can also be your existing document root

--- a/doc/etemplate2/pages/tutorials/converting-to-webcomponents.md
+++ b/doc/etemplate2/pages/tutorials/converting-to-webcomponents.md
@@ -18,7 +18,7 @@ widgets. This can cause issues when they are used together.
 | get_\[property]()                                              | widget.\[property]                                                                                                       |
 | set_value(...)                                                 | set_value(...) remains, but is only used when loading content from a template file.                                      |
 | getValue()                                                     | getValue() remains but is only used when the etemplate is submitted.    Prefer `widget.value` for most cases.            |
-| loadingFinished(waiting : Promise[])                           | loadingFinished(waiting:Promise[]) remains for legacy compatability, but waiting for updateComplete() is the replacement |
+| loadingFinished(waiting : Promise[])                           | loadingFinished(waiting:Promise[]) remains for legacy compatibility, but waiting for updateComplete() is the replacement |
 
 ### Accessing widget internals
 


### PR DESCRIPTION
Three typo fixes:

- `doc/docker/development/README.md:1` and `:3` — `enviroment` → `environment` (the heading and the first line of body text)
- `doc/etemplate2/pages/tutorials/converting-to-webcomponents.md:21` — `compatability` → `compatibility`

Docs only.
