### PR TITLE
Api: fix fresh install aborting on missing egw_notificationpopup table

### DIFF
--- a/admin/js/app.ts
+++ b/admin/js/app.ts
@@ -84,21 +84,6 @@ export class AdminApp extends EgwApp
 	private _adminIframeLoadHandler : () => void = () => {};
 
 	/**
-	 * Get the real <iframe> DOM node for an iframe widget
-	 *
-	 * Et2Iframe (the webcomponent) keeps its actual <iframe> inside a shadow root -
-	 * widget.getDOMNode() (inherited, unoverridden) returns the <et2-iframe> host element
-	 * instead, which has neither a `load` event nor `contentDocument`/`contentWindow`.
-	 * __getIframeNode() is Et2Iframe's own accessor for the real node. Falls back to
-	 * getDOMNode() for the legacy et2_iframe widget, where that already *is* the real iframe.
-	 */
-	private static realIframeNode(widget : any) : HTMLIFrameElement
-	{
-		if(!widget) return null;
-		return (typeof widget.__getIframeNode === 'function' ? widget.__getIframeNode() : widget.getDOMNode()) || null;
-	}
-
-	/**
 	 * Constructor
 	 *
 	 * @memberOf app.classes.admin
@@ -160,7 +145,7 @@ export class AdminApp extends EgwApp
 				// iframe is a fresh DOM node every time this case runs, but keep the
 				// removeEventListener-before-addEventListener pattern (native equivalent
 				// of jQuery's off()+bind()) in case the widget/node is ever reused.
-				const iframeNode = iframe && AdminApp.realIframeNode(iframe);
+				const iframeNode = iframe?.iframe;
 				if (iframeNode)
 				{
 					iframeNode.removeEventListener('load', this._adminIframeLoadHandler);
@@ -240,7 +225,7 @@ export class AdminApp extends EgwApp
 	 */
 	load(_url? : string)
 	{
-		if (this.iframe && AdminApp.realIframeNode(this.iframe)?.contentDocument?.location.href
+		if (this.iframe && this.iframe.iframe?.contentDocument?.location.href
 			.match(/menuaction=admin.admin_statistics.submit.+required=true/) && ( !_url ||
 			!_url.match(/statistics=(postpone|canceled|submitted)/)))
 		{
@@ -305,7 +290,7 @@ export class AdminApp extends EgwApp
 		{
 			this.egw.app_header('');
 			// blank iframe, to not keep something running there
-			const iframeNode = this.iframe && AdminApp.realIframeNode(this.iframe);
+			const iframeNode = this.iframe && this.iframe.iframe;
 			if(iframeNode)
 			{
 				iframeNode.contentDocument.location.href = 'about:blank';
@@ -357,7 +342,7 @@ export class AdminApp extends EgwApp
 		{
 			case 'admin':
 				// if iframe is used --> refresh it
-				const iframe_node = this.iframe ? AdminApp.realIframeNode(this.iframe) : undefined;
+				const iframe_node = this.iframe ? this.iframe.iframe : undefined;
 				const iframe_url = iframe_node ? iframe_node.contentDocument.location.href : undefined;
 				if (_id && iframe_url != 'about:blank')
 				{

--- a/api/js/etemplate/Et2Iframe/Et2Iframe.ts
+++ b/api/js/etemplate/Et2Iframe/Et2Iframe.ts
@@ -93,6 +93,19 @@ export class Et2Iframe extends Et2Widget(LitElement)
 	}
 
 	/**
+	 * The real <iframe> DOM node inside this widget's shadow root
+	 *
+	 * getDOMNode() (inherited from Et2Widget, unoverridden) returns the <et2-iframe> host
+	 * element itself - generic framework code relies on that for placement/visibility/sizing.
+	 * Consumers that need the actual iframe (its contentDocument/contentWindow, a 'load'
+	 * listener, ...) should use this instead of reaching for __getIframeNode() directly.
+	 */
+	get iframe() : HTMLIFrameElement
+	{
+		return this.__getIframeNode();
+	}
+
+	/**
 	 * The url last handed to the <iframe>, so updated() does not load again what set_src()
 	 * has just loaded
 	 */

--- a/api/js/etemplate/Et2Nextmatch/Et2NextmatchActionController.ts
+++ b/api/js/etemplate/Et2Nextmatch/Et2NextmatchActionController.ts
@@ -16,6 +16,9 @@ import {
 } from "../../egw_action/egw_action_constants";
 import type {ReactiveController} from "lit";
 import type {Et2Nextmatch} from "./Et2Nextmatch";
+import {Et2Dialog} from "../Et2Dialog/Et2Dialog";
+import {nm_open_popup} from "../et2_extension_nextmatch_actions.js";
+import {et2_warnOnce} from "../Et2Widget/Et2Widget";
 
 /**
  * Minimal AOI base used by Et2Nextmatch.
@@ -1464,6 +1467,23 @@ export class Et2NextmatchActionController implements ReactiveController
 
 	/**
 	 * Open a configured action popup/dialog for the selected provider row ids.
+	 *
+	 * The popup markup is normally a real `<et2-dialog>`, shown directly. Some apps still
+	 * declare it as a plain, CSS-toggled element (eg. `<et2-box class="action_popup prompt">`)
+	 * left over from the legacy `<nextmatch>` widget. For those, delegate to nm_open_popup()
+	 * (et2_extension_nextmatch_actions.js), which upgrades the element into a real dialog in
+	 * place - the same upgrade already relied on by the handful of actions whose onExecute
+	 * calls nm_open_popup() directly. This keeps both paths behaving identically instead of
+	 * silently falling through to a real form submit when the popup never opens.
+	 *
+	 * nm_open_popup() is deliberately given `selectedIds` (plain row id strings) rather than
+	 * richer `EgwActionObject` senders: it treats an object sender as a legacy
+	 * `et2_dataview_controller_selection`-style row with a `_context._widget` back-reference,
+	 * which modern Et2Nextmatch row objects don't have (`_context` is the row element itself) -
+	 * passing real senders would silently clobber the `action.data.nextmatch` we just set below
+	 * and break the resulting submit. A plain id array is exactly what the legacy `<nextmatch>`
+	 * widget's own default open_popup handling already passes it, so this matches existing,
+	 * working behaviour.
 	 */
 	private openActionPopup(action : EgwAction, selectedIds : string[]) : boolean
 	{
@@ -1479,22 +1499,20 @@ export class Et2NextmatchActionController implements ReactiveController
 		}
 		action.data.nextmatch = this.host;
 		(popup as any).selectedIds = selectedIds;
-		if(typeof (popup as any).show === "function")
+
+		if(popup instanceof Et2Dialog)
 		{
 			(popup as any).show();
 			return true;
 		}
-		if(typeof (popup as any).open === "boolean")
-		{
-			(popup as any).open = true;
-			return true;
-		}
-		if(typeof (popup as any).showModal === "function")
-		{
-			(popup as any).showModal();
-			return true;
-		}
-		return false;
+
+		et2_warnOnce(this.host, "legacy-action-popup:" + popup.id,
+			`Action popup #${popup.id} is a plain element, not an <et2-dialog>; upgrading it at ` +
+			"runtime for backwards compatibility. Please change its template to a real <et2-dialog>.",
+			popup
+		);
+		nm_open_popup(action, selectedIds);
+		return true;
 	}
 
 	/**

--- a/api/js/etemplate/Et2Nextmatch/test/Et2Nextmatch.actions.test.ts
+++ b/api/js/etemplate/Et2Nextmatch/test/Et2Nextmatch.actions.test.ts
@@ -3,6 +3,7 @@ import {Et2Nextmatch} from "../Et2Nextmatch";
 import {Et2NextmatchActionController, resolveActionApiGetters} from "../Et2NextmatchActionController";
 import {EgwPopupActionImplementation} from "../../../egw_action/EgwPopupActionImplementation";
 import {egw_getActionManager, egw_getObjectManager} from "../../../egw_action/egw_action";
+import {Et2Dialog} from "../../Et2Dialog/Et2Dialog";
 import * as sinon from "sinon";
 
 const egwStub = {
@@ -1345,6 +1346,70 @@ describe("Et2Nextmatch action setup", () =>
 		el.executeAction("view_org", undefined, {nmAction: "submit"});
 
 		assert.deepEqual(el.value.selected, ["99"], "omitted selection should use the nextmatch current selection");
+	});
+
+	/**
+	 * Contract under test:
+	 * - Several apps (eg. tracker, infolog) still declare an "open_popup" action's popup as a
+	 *   plain, CSS-toggled element (`<et2-box id="foo_popup" class="action_popup prompt">`) left
+	 *   over from the legacy `<nextmatch>` widget, instead of a real `<et2-dialog>`.
+	 * - openActionPopup() must upgrade that element into a real dialog and open it - like
+	 *   nm_open_popup() already does for the few actions whose onExecute calls it directly -
+	 *   instead of failing to find a dialog API on it and silently falling through to a real
+	 *   form submit.
+	 *
+	 * Setup strategy:
+	 * - Build a minimal non-dialog popup element (plain box, ".promptheader" title, one
+	 *   "et2-button" child) named "<action id>_popup", matching the affected templates.
+	 * - Execute the action as "open_popup".
+	 *
+	 * Pass criteria:
+	 * - The instance manager's submit() is never called.
+	 * - The popup element is upgraded in place into an Et2Dialog and shown.
+	 */
+	it("upgrades a legacy non-dialog action popup instead of falling through to submit", () =>
+	{
+		const el = new Et2Nextmatch();
+		el.id = "nm";
+		const submit = sinon.spy();
+		el.setInstanceManager({
+			submit,
+			DOMContainer: document.body,
+			app: "tracker",
+			uniqueId: "nm_legacy_popup_uid"
+		} as any);
+
+		const popup = document.createElement("div");
+		popup.id = "admin_popup";
+		popup.className = "action_popup prompt";
+		const header = document.createElement("div");
+		header.className = "promptheader";
+		popup.append(header);
+		popup.append(document.createElement("et2-button"));
+		document.body.append(popup);
+
+		const action : any = {id: "admin", data: {}};
+		const controller : any = (el as any)._actionController;
+		controller.actionManager = {
+			getActionById: (id) => id === "admin" ? action : null,
+			getActionsByAttr: () => []
+		};
+
+		try
+		{
+			const handled = el.executeAction("admin", {ids: ["tracker::10"], all: false}, {nmAction: "open_popup"});
+
+			assert.isTrue(handled, "open_popup action should report itself as handled");
+			assert.isFalse(submit.called, "a legacy non-dialog popup must not fall through to a real submit");
+
+			const upgraded = document.body.querySelector("#admin_popup");
+			assert.instanceOf(upgraded, Et2Dialog, "plain popup element should be upgraded into a real dialog");
+			assert.isTrue((upgraded as any).open, "upgraded dialog should be shown");
+		}
+		finally
+		{
+			document.body.querySelector("#admin_popup")?.remove();
+		}
 	});
 
 	/**

--- a/api/src/Db.php
+++ b/api/src/Db.php
@@ -854,6 +854,7 @@ class Db
 					1064,   // You have an error in your SQL syntax
 					1062,   // Duplicate entry
 					1054,   // Unknown column 'X' in ...
+					1146,   // Table 'X' doesn't exist
 				]))
 				{
 					$e = new Db\Exception\InvalidSql($e->getMessage(), $e->getCode(), $e);

--- a/api/tests/Db/QuoteTest.php
+++ b/api/tests/Db/QuoteTest.php
@@ -309,14 +309,14 @@ class QuoteTest extends TestCase
 
 	/**
 	 * query()'s error-classification distinguishes InvalidSql (for a MySQL error code in
-	 * [1064 syntax, 1062 duplicate-key, 1054 unknown-column]) from a generic Db\Exception for
-	 * everything else - that distinction lives in the `catch(\mysqli_sql_exception $e)` block,
-	 * which requires mysqli's modern exception-throwing mode. mysqli_report(MYSQLI_REPORT_ERROR |
-	 * MYSQLI_REPORT_STRICT) is now explicitly re-enabled in Db::_connect() (ADOdb's mysqli driver
-	 * constructor forces it back OFF otherwise, undoing PHP 8.1+'s own default - see the fix commit
-	 * for details), so this classification is genuinely live: a SQL-syntax error (code 1064, IN the
-	 * list) throws InvalidSql, with the SQL text recoverable via $e->details (set by the catch
-	 * block's re-throw).
+	 * [1064 syntax, 1062 duplicate-key, 1054 unknown-column, 1146 unknown-table]) from a generic
+	 * Db\Exception for everything else - that distinction lives in the
+	 * `catch(\mysqli_sql_exception $e)` block, which requires mysqli's modern exception-throwing
+	 * mode. mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT) is now explicitly re-enabled
+	 * in Db::_connect() (ADOdb's mysqli driver constructor forces it back OFF otherwise, undoing
+	 * PHP 8.1+'s own default - see the fix commit for details), so this classification is genuinely
+	 * live: a SQL-syntax error (code 1064, IN the list) throws InvalidSql, with the SQL text
+	 * recoverable via $e->details (set by the catch block's re-throw).
 	 */
 	public function testQuerySyntaxErrorThrowsInvalidSqlWithSqlInDetails()
 	{
@@ -335,12 +335,16 @@ class QuoteTest extends TestCase
 	}
 
 	/**
-	 * A non-existent-table error (code 1146) is NOT in the InvalidSql code list, so it must throw
-	 * the generic Api\Db\Exception, not the InvalidSql subclass - confirming the fine-grained
-	 * code-based classification is genuinely live now that mysqli throws (see the class doc-comment
-	 * on the previous test).
+	 * A non-existent-table error (code 1146) must throw InvalidSql, not just the generic
+	 * Api\Db\Exception: several places deliberately catch InvalidSql to keep working against a
+	 * table that does not exist (yet), most importantly during a fresh installation, where
+	 * Api\Link::delete_cache() and notifications_push::addGeneric() push to egw_notificationpopup
+	 * long before the notifications app is installed, and Api\Egw::__construct() probes egw_config
+	 * to decide whether to redirect to setup. It is also what every non-mysqli driver does: the
+	 * `if (!$rs)` branch further down query() raises InvalidSql for any SQL error, whatever its
+	 * code, so leaving 1146 out here would make mysqli the odd one out.
 	 */
-	public function testQueryUnknownTableThrowsGenericDbExceptionNotInvalidSql()
+	public function testQueryUnknownTableThrowsInvalidSql()
 	{
 		$table = 'egw_nonexistent_table_'.bin2hex(random_bytes(4));
 
@@ -351,12 +355,31 @@ class QuoteTest extends TestCase
 		}
 		catch (Api\Db\Exception\InvalidSql $e)
 		{
-			$this->fail('Error code 1146 (unknown table) is not in the InvalidSql code list - '.
-				'must be a generic Db\Exception, not InvalidSql: '.$e->getMessage());
+			$this->assertStringContainsString($table, $e->getMessage());
+		}
+	}
+
+	/**
+	 * A code that is NOT in the InvalidSql list - 1136 "Column count doesn't match value count" -
+	 * must throw the generic Api\Db\Exception, confirming the fine-grained code-based
+	 * classification is genuinely live now that mysqli throws (see the class doc-comment on
+	 * testQuerySyntaxErrorThrowsInvalidSqlWithSqlInDetails).
+	 */
+	public function testQueryUnclassifiedErrorThrowsGenericDbExceptionNotInvalidSql()
+	{
+		try
+		{
+			self::$db->query("INSERT INTO egw_test (t_uniq) VALUES ('a', 'b')", __LINE__, __FILE__);
+			$this->fail('Expected an exception for a mismatched column/value count');
+		}
+		catch (Api\Db\Exception\InvalidSql $e)
+		{
+			$this->fail('Error code 1136 (column count mismatch) is not in the InvalidSql code '.
+				'list - must be a generic Db\Exception, not InvalidSql: '.$e->getMessage());
 		}
 		catch (Api\Db\Exception $e)
 		{
-			$this->assertStringContainsString($table, $e->getMessage());
+			$this->assertSame(1136, $e->getCode());
 		}
 	}
 

--- a/calendar/inc/class.calendar_boupdate.inc.php
+++ b/calendar/inc/class.calendar_boupdate.inc.php
@@ -3525,9 +3525,22 @@ class calendar_boupdate extends calendar_bo
     }
 
 	/**
+	 * Id of the async job used to continue a purge that did not finish within the time-limit
+	 */
+	const PURGE_CONTINUE_ID = 'calendar_purge_continue';
+
+	/**
+	 * Maximum time in seconds a single purge() run is allowed to take
+	 */
+	const PURGE_TIME_LIMIT = 300;	// 5 minutes
+
+	/**
 	 * Delete events that are more than $age years old
 	 *
-	 * Purges old events from the database
+	 * Purges old events from the database, oldest (lowest cal_id) first. As purging
+	 * everything could take a long time, a single run is limited to self::PURGE_TIME_LIMIT
+	 * seconds. If that is not enough to purge everything, an async job is (re-)scheduled
+	 * to continue the purge on the next async tick, until everything is purged.
 	 *
 	 * @param int|float $age How many years old the event must be before it is deleted
 	 */
@@ -3537,7 +3550,16 @@ class calendar_boupdate extends calendar_bo
 		{
 			$cutoff = new DateTime('now', DateTime::$server_timezone);
 			$cutoff->modify('-'.round(365 * (float)$age).' days');
-			$this->so->purge($cutoff);
+			$more = $this->so->purge($cutoff, self::PURGE_TIME_LIMIT);
+
+			// (re-)schedule an async job to continue the purge on the next async tick, resp.
+			// cancel a previously scheduled one, if we are done
+			$async = new Api\Asyncservice();
+			$async->cancel_timer(self::PURGE_CONTINUE_ID);
+			if ($more)
+			{
+				$async->set_timer(time()+1, self::PURGE_CONTINUE_ID, 'calendar.calendar_boupdate.purge', $age);
+			}
 		}
 	}
 

--- a/calendar/inc/class.calendar_so.inc.php
+++ b/calendar/inc/class.calendar_so.inc.php
@@ -2646,15 +2646,29 @@ ORDER BY cal_user_type, cal_usre_id
 	 * Recurring events that span the date will be ignored.  Non-recurring
 	 * events before the date will be deleted.
 	 *
+	 * Oldest events (lowest cal_id) are purged first, and the loop stops once
+	 * $time_limit is exceeded, so a single call never runs unbound (and does not
+	 * block the async service, or a request, for an unlimited time). The caller
+	 * has to keep calling this, as long as it returns true, to purge everything.
+	 *
 	 * @param DateTime $date
+	 * @param int $time_limit =300 maximum number of seconds this method is allowed to run
+	 * @return bool true if the time-limit was hit before everything before $date got purged, false if done
 	 * @throws Api\Db\Exception
 	 * @throws Api\Db\Exception\InvalidSql
 	 */
-	function purge(DateTime $date) : void
+	function purge(DateTime $date, int $time_limit=300) : bool
 	{
+		$start = microtime(true);
+
 		// with new range_end we simple delete all with range_end < $date (range_end NULL is never returned)
-		foreach($this->db->select($this->cal_table, 'cal_id', 'range_end < ' . (int)$date->format('server'), __LINE__, __FILE__, false, '', 'calendar') as $row)
+		// order by cal_id ASC, to purge the oldest events first
+		foreach($this->db->select($this->cal_table, 'cal_id', 'range_end < ' . (int)$date->format('server'), __LINE__, __FILE__, false, 'ORDER BY cal_id ASC', 'calendar') as $row)
 		{
+			if (microtime(true) - $start > $time_limit)
+			{
+				return true;	// time is up, though there might be more events left to purge
+			}
 			//echo __METHOD__." About to delete".$row['cal_id']."\r\n";
 			foreach($this->all_tables as $table)
 			{
@@ -2663,6 +2677,7 @@ ORDER BY cal_user_type, cal_usre_id
 			// handle links
 			Link::unlink('', 'calendar', $row['cal_id']);
 		}
+		return false;
 	}
 
 	/**

--- a/calendar/tests/PurgeTest.php
+++ b/calendar/tests/PurgeTest.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Tests for calendar's old-event purge (calendar_so::purge / calendar_boupdate::purge)
+ *
+ * @package calendar
+ * @subpackage tests
+ */
+
+namespace EGroupware\calendar;
+
+require_once realpath(__DIR__ . '/../../api/tests/AppTest.php'); // Application test base
+
+use EGroupware\Api;
+
+class PurgeTest extends \EGroupware\Api\AppTest
+{
+	protected $bo;
+	protected $so;
+	protected $event_ids = [];
+
+	protected function setUp() : void
+	{
+		parent::setUp();
+		$this->bo = new \calendar_boupdate();
+		$this->so = new \calendar_so();
+	}
+
+	protected function tearDown() : void
+	{
+		foreach($this->event_ids as $id)
+		{
+			// ensure cleanup, call twice as some tests do keep-deleted behaviour
+			$this->bo->delete($id, 0, true);
+			$this->bo->delete($id, 0, true);
+		}
+		// make sure no continuation job is left behind for the real async service to pick up
+		(new Api\Asyncservice())->cancel_timer(\calendar_boupdate::PURGE_CONTINUE_ID);
+
+		parent::tearDown();
+	}
+
+	protected function create_event($days_offset)
+	{
+		$start = new Api\DateTime('now', Api\DateTime::$server_timezone);
+		$start->modify($days_offset.' days');
+		$end = clone $start;
+		$end->modify('+1 hour');
+
+		$id = $this->bo->save([
+			'title' => 'Purge test event '.uniqid(),
+			'owner' => $GLOBALS['egw_info']['user']['account_id'],
+			'start' => $start,
+			'end'   => $end,
+		]);
+		$this->assertGreaterThan(0, $id, 'saved event id should be > 0');
+		$this->event_ids[] = $id;
+
+		return $id;
+	}
+
+	/**
+	 * Pass criteria:
+	 * - the event older than the cutoff gets purged
+	 * - the event on/after the cutoff is left alone
+	 * - purge() reports it finished (false), having processed everything within the time-limit
+	 */
+	public function testPurgeRespectsCutoff()
+	{
+		$old_id = $this->create_event(-60);
+		$future_id = $this->create_event(60);
+
+		$cutoff = new Api\DateTime('now', Api\DateTime::$server_timezone);
+		$cutoff->modify('-30 days');
+
+		$more = $this->so->purge($cutoff, 300);
+
+		$this->assertFalse($more, 'purge() should report it finished within the time-limit');
+		$this->assertNull($this->bo->read($old_id), 'event older than cutoff should have been purged');
+		$this->assertNotFalse($this->bo->read($future_id), 'event newer than cutoff should be untouched');
+
+		// it's already gone, do not try to delete it again in tearDown
+		$this->event_ids = array_diff($this->event_ids, [$old_id]);
+	}
+
+	/**
+	 * Pass criteria:
+	 * - an already-exhausted time-limit stops the loop before touching any row
+	 * - purge() reports there is more work left (true)
+	 */
+	public function testPurgeTimeLimitStopsImmediately()
+	{
+		$old_id = $this->create_event(-60);
+
+		$cutoff = new Api\DateTime('now', Api\DateTime::$server_timezone);
+		$cutoff->modify('-30 days');
+
+		// a negative time-limit is already exceeded before the first row is even checked
+		$more = $this->so->purge($cutoff, -1);
+
+		$this->assertTrue($more, 'purge() should report unfinished work when the time-limit is already up');
+		$this->assertNotFalse($this->bo->read($old_id), 'event should not have been purged when the time-limit was already exhausted');
+	}
+
+	/**
+	 * Pass criteria:
+	 * - when calendar_so::purge() reports unfinished work, calendar_boupdate::purge()
+	 *   schedules an async job to continue purging on the next async tick
+	 * - once calendar_so::purge() reports it's done, that continuation job is removed again
+	 */
+	public function testBoupdatePurgeSchedulesContinuation()
+	{
+		$async = new Api\Asyncservice();
+
+		$unfinished_so = $this->getMockBuilder(\calendar_so::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['purge'])
+			->getMock();
+		$unfinished_so->method('purge')->willReturn(true);
+		$this->bo->so = $unfinished_so;
+
+		$this->bo->purge(1);
+
+		$job = $async->read(\calendar_boupdate::PURGE_CONTINUE_ID);
+		$this->assertNotFalse($job, 'a continuation job should be scheduled while more purging is left to do');
+		$job = $job[\calendar_boupdate::PURGE_CONTINUE_ID];
+		$this->assertGreaterThan(time(), $job['next'], 'continuation job should be scheduled for a future tick, not run inline');
+
+		$finished_so = $this->getMockBuilder(\calendar_so::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['purge'])
+			->getMock();
+		$finished_so->method('purge')->willReturn(false);
+		$this->bo->so = $finished_so;
+
+		$this->bo->purge(1);
+
+		$this->assertFalse($async->read(\calendar_boupdate::PURGE_CONTINUE_ID), 'continuation job should be cancelled once purging is finished');
+	}
+}

--- a/doc/ai/projects/et2-property-decorator-migration.md
+++ b/doc/ai/projects/et2-property-decorator-migration.md
@@ -1,0 +1,237 @@
+# Et2* Widgets: `static get properties()` → `@property()` Decorators
+
+## Goal
+
+Every `Et2*`/webcomponent widget still declaring its Lit reactive properties the old way —
+
+    static get properties() { return {...super.properties, foo: {type: String}}; }
+
+— gets converted to real, `tsc`-visible class fields:
+
+    @property({type: String}) foo = "";
+
+matching the convention already used by `Et2File.ts`, `Et2Button.ts`, `Et2Avatar.ts`, etc. This is a
+**compile-time-safety fix, not a runtime behaviour change**: Lit registers the identical reactive
+property either way. The bug class this closes is real and already bit us once - see
+`Et2Iframe.ts`'s `this.options.name` incident (`widget-migration-status.md`'s `iframe` row) - a
+`static get properties()` file gives `tsc` nothing to check, so a typo'd or wrong property name in
+`render()`/a setter/an external consumer is silently accepted as `any`.
+
+No config change is required first: `tsconfig.json` already has `useDefineForClassFields: false` +
+`experimentalDecorators: true` (the combination legacy Lit decorators need - if it were `true`, a
+class-field initializer would shadow the decorator-installed accessor via `Object.defineProperty` at
+construction time and silently break reactivity). `Et2File.ts` already proves this setting works
+correctly in this codebase, so that classic Lit/TS footgun does not apply here.
+
+## Inventory
+
+**40 files** in `api/js/etemplate/` still declare a real `static get properties()`. (The initial
+`grep -rl "static get properties"` hit 42; `Et2Tree/Et2Tree.ts` is a **false positive** - only a
+stale comment (`// @ts-ignore from static get properties`) survives, the class is already fully
+decorator-based; `Et2Datagrid/test/Et2Datagrid.test.ts` is a test fixture, not a widget.)
+
+Of those 40:
+- **35** are pure legacy (zero `@property` anywhere in the file).
+- **5** are mixed (already partly converted, but a `static get properties()` remnant survives):
+  `Et2InputWidget.ts`, `Et2Widget.ts`, `Et2Select/Et2Select.ts`, `Et2Select/Select/Et2SelectReadonly.ts`,
+  `Et2DropdownButton.ts`.
+- **4** are no-op overrides - `{...super.properties}` with nothing of their own added - pure dead
+  code: `Et2Date/Et2DateTime.ts`, `Et2Date/Et2DateTimeOnly.ts`, `Et2DropdownButton/Et2DropdownButton.ts`,
+  `Layout/RowLimitedMixin.ts`. These can simply be **deleted**, not converted.
+- **744 of the repo's 4465 `npm run typecheck` errors (~17%)** are directly attributable to lines
+  inside these 40 files - a concrete, measurable chunk of the compiler-error backlog this closes.
+- **19 of 40** have no `test/*.test.ts` directory at all; the rest do.
+- **15 of 40** have at least one property with a **hand-written `get`/`set` accessor colliding with
+  the property name** - the case flagged in the task as needing care. Good news: this is not a new
+  pattern to invent. The codebase already has a precedented fix, used 3 times in already-migrated
+  files (`Et2Button.ts:51`, `Et2Avatar.ts:187`, `Et2Select/Et2WidgetWithSelectMixin.ts:88`): put
+  `@property({..., noAccessor: true})` directly on the existing `get`/`set`, don't add a class field.
+
+Outside `api/js/etemplate/`: no old-pattern custom elements in `kdots/`, `rocketchat/` (which has no
+custom elements of its own at all), or any other in-repo app `js/` directory. The one exception is
+**`smallpart/`** - its own nested git repo (own `.git`, no own `tsconfig.json`/`package.json`, but
+covered by the root `tsconfig.json`'s `**/js/**/*.ts` include glob, and it does show up in
+`npm run typecheck` output, under both `smallpart/js/...` and the `vendor/egroupware/smallpart/js/...`
+copy). **Out of scope for this project entirely** - it's a separate nested repo on someone else's
+release cadence, not just a separately-committed batch. Not touching it.
+
+### Full table - `api/js/etemplate/`
+
+| File | Own props | Collision(s) | Tests? | tsc errors now |
+|---|---|---|---|---|
+| Et2Widget/Et2Widget.ts *(base, 41 extenders)* | ~12 | class, parentId, statustext, data, actions | 2 files | 42 |
+| Et2InputWidget/Et2InputWidget.ts *(base, 32 extenders)* | 9 | label (`noAccessor` already set) | 1 file | 60 |
+| Et2Select/Et2Select.ts | 2 | - | 8 files | 63 |
+| Layout/Et2Tabs/Et2Tabs.ts | 5 | value | none | 68 |
+| Et2Textbox/Et2Password.ts | 2 | - | 3 files | 59 |
+| Et2Button/ButtonMixin.ts *(mixin)* | 4 | image | 2 files | 35 |
+| Layout/Et2Split/Et2Split.ts | 3 | orientation | none | 32 |
+| Et2Favorites/Et2Favorites.ts | 3 | - | none | 32 |
+| Et2Date/Et2Date.ts | 4 | placement | 4 files | 30 |
+| Et2Select/Select/Et2SelectReadonly.ts | 1 | value, select_options | none | 29 |
+| Et2Description/Et2Description.ts | 6 | value | 1 file | 25 |
+| Et2Date/Et2DateRange.ts | 2 | - | 4 files | 25 |
+| Et2Portlet/Et2Portlet.ts | 5 | - | none | 23 |
+| Et2Link/Et2LinkList.ts | 2 | - | 3 files | 22 |
+| Et2Url/Et2InvokerMixin.ts *(mixin)* | 3 | - | 1 file | 20 |
+| Et2Switch/Et2Switch.ts | 2 | - | 2 files | 18 |
+| Et2Iframe/Et2Iframe.ts | 7 | - | 1 file | 15 |
+| Et2DropdownButton/Et2DropdownButton.ts | 0 (delete) | - | none | 13 |
+| Et2Textarea/Et2Textarea.ts | 2 | width, height | none | 12 |
+| Et2Date/Et2DateReadonly.ts | 1 | - | 4 files | 12 |
+| Et2Checkbox/Et2CheckboxReadonly.ts | 5 | - | none | 12 |
+| Expose/ExposeMixin.ts *(mixin)* | 3 | - | none | 11 |
+| Et2Link/Et2LinkSearch.ts | 1 | - | 3 files | 11 |
+| Et2Url/Et2Url.ts | 2 | - | 1 file | 10 |
+| Et2Link/Et2LinkAppSelect.ts | 3 | onlyApp, applicationList | 3 files | 10 |
+| Et2Button/Et2ButtonTimestamper.ts | 3 | - | 2 files | 9 |
+| Et2Select/Select/Et2SelectNumber.ts | 5 | - | none | 7 |
+| Et2Date/Et2DateSince.ts | 1 | - | 4 files | 7 |
+| Et2Spinner/Et2Spinner.ts | 1 | - | none | 5 |
+| Et2Link/Et2Link.ts | 7 | value | 3 files | 5 |
+| Et2Avatar/Et2AvatarGroup.ts | 1 | - | none | 5 |
+| Expose/Et2DescriptionExpose.ts | 2 | - | none | 4 |
+| Layout/RowLimitedMixin.ts *(mixin)* | 0 (delete) | - | none | 3 |
+| Et2Select/Select/Et2SelectCountry.ts | 1 | - | none | 3 |
+| Layout/Et2Tabs/Et2TabPanel.ts | 1 | - | none | 2 |
+| Et2Select/Select/Et2SelectState.ts | 1 | countryCode | none | 2 |
+| Et2Date/Et2DateTimeOnly.ts | 0 (delete) | - | 4 files | 2 |
+| Et2Date/Et2DateTime.ts | 0 (delete) | - | 4 files | 1 |
+| Et2Nextmatch/Headers/CustomFilterHeader.ts | 2 | - | none | 0 |
+| Et2Nextmatch/ColumnSelection.ts | 3 | value, columns, autoRefresh | 10 files | 0 |
+
+*(Property/error counts are "roughly" per the task's own instruction - extracted mechanically, not
+hand-verified line by line; good enough to plan batches, not to cite in a commit message.)*
+
+## Risk assessment
+
+**Not a pure no-op for every file.** Three real footguns, none of them the
+`useDefineForClassFields` one:
+
+1. **Getter/setter collisions (15 files).** A hand-written `get`/`set` for the same name as a
+   `static get properties()` entry must become `@property({..., noAccessor: true})` placed directly
+   on the accessor - not a separate class-field declaration, which would produce a duplicate member
+   error or silently shadow the accessor. Precedented 3x already in this repo; not a new invention,
+   but easy to get wrong by pattern-matching on `Et2File.ts` instead (which has no collisions).
+   **Highest-risk subset**: collision **and** zero test coverage - `Et2SelectState.ts`,
+   `Et2SelectReadonly.ts`, `Et2Split.ts`, `Layout/Et2Tabs/Et2Tabs.ts`. Consider a quick
+   characterization test before converting these four, same philosophy as
+   `et2select-searchmixin-removal.md` §8.
+2. **Mixins** (`ButtonMixin`, `ExposeMixin`, `Et2InvokerMixin`, `RowLimitedMixin`) apply to multiple
+   host classes - a mistake ripples across every consumer. `Et2Select/Et2WidgetWithSelectMixin.ts`
+   already proves `@property()` works fine inside a mixin factory function, so this is a blast-radius
+   concern, not a new technical risk.
+3. **Base classes** `Et2Widget.ts` (41 direct extenders) and `Et2InputWidget.ts` (32 extenders) carry
+   the most collisions and the most pre-existing tsc errors (42 and 60) - highest value, but do them
+   **last**, once the pattern is proven on leaf widgets, and smoke-test broadly afterward.
+
+**Explicitly out of scope, flagged for a separate pass:** 32 of these 40 files register with
+`customElements.define("et2-x", X)` + `// @ts-ignore` instead of the `@customElement("et2-x")`
+decorator `Et2File.ts` uses. (Of the rest: `Et2Select.ts` and `CustomFilterHeader.ts` already use the
+decorator; the other 6 - `ButtonMixin`, `Et2InvokerMixin`, `ExposeMixin`, `RowLimitedMixin`,
+`Et2InputWidget.ts`, `Et2Widget.ts` - are mixins/base classes that never call `customElements.define`
+themselves, so the check doesn't apply to them.) Same modernization spirit, unrelated
+compiler-safety win, don't bundle it into this migration - it changes a different thing (registration
+timing/class identity) and would make each diff harder to review as "just the property fix."
+
+One live bug found while checking this: `Et2Select.ts:1307-1310` still has a leftover
+`customElements.define("et2-select", Et2Select)` call guarded by
+`if (typeof customElements.get("et2-select") === "undefined")`, dating from before it was converted
+to `@customElement('et2-select')` (line 98). Since the decorator registers the element the moment the
+class statement executes, the guard is always false by the time this later code runs - it's dead code.
+It's the only file among the 51 already-`@customElement`-converted files with this leftover. Worth a
+one-line standalone cleanup, not part of this migration.
+
+## `@state()` candidates found in passing
+
+While inventorying properties for the conversion above, a few looked like they'd be better declared
+`@state()` (internal reactive field, no attribute reflection, not meant to be set by template markup
+or external/consumer JS) rather than `@property()` (real public API). Evidence gathered by grepping
+for `.xet` attribute usage and external JS reads/writes, excluding each widget's own file and test.
+
+**Real candidates - convert to `@state()` instead of `@property()`:**
+- `Et2CheckboxReadonly.ts`'s `checked` - no `.xet` ever sets `checked=`, not in
+  `getDetachedAttributes()`'s push list (only `value`/`class`/`statustext` are), no external write
+  found; only read inside its own `render()`.
+- `Et2InvokerMixin.ts`'s `_invokerLabel`, `_invokerTitle`, `_invokerAction` - already
+  underscore-prefixed, zero `.xet`/external-app usage, set only by cooperating sibling subclasses
+  (`Et2Url`, `Et2UrlEmail`, `Et2UrlPhone`, `Et2UrlFax`, `Et2Password`) constructing their own invoker
+  button. Internal to the mixin family, not public API.
+- `Et2Spinner.ts`'s `style` - the whole widget has zero consumers repo-wide, and the property shadows
+  the native `HTMLElement.style` accessor, which is worth fixing independent of the `@state` question.
+
+**Good precedent already in the repo**: `Et2Select.ts`'s `_tagsHidden`/`_optionsActivated` are already
+correctly `@state()` - use that as the template when converting the above.
+
+**Not a state question - dead/orphaned wiring, flag separately, don't fold into this migration:**
+- `ColumnSelection.ts`'s `autoRefresh` - no external `.autoRefresh` set anywhere, and
+  `footerTemplate()`, the only place that touches it, is never called from `render()`.
+- `ExposeMixin.ts`'s `mediaContentFunction` - actually read via a different, never-assigned field
+  (`this.__mediaContentFunction`); looks like broken wiring.
+- `Et2Iframe.ts`'s `needed` - declared, never read anywhere in the class, no setter, no external
+  reference; looks like copy/paste leftover from an input widget.
+
+**Documented-but-currently-unused public config, keep as `@property()`:** `Et2DateRange.relative`/
+`value`, `Et2Date.inline`, `Et2DateSince.units`, `Et2ButtonTimestamper.format`/`timezone`,
+`Et2Url.trailingSlash`, `CustomFilterHeader.widgetOptions`, `Et2Portlet.editTemplate`,
+`Et2Link.linkHook`/`targetApp`/`extraLinkTarget`/`breakTitle`, `Et2Iframe.seamless`/`fullscreen`/
+`allow`. These have JSDoc, `set_X()` methods, or `reflect:true` signaling real public-API intent -
+just no live caller in the current templates yet. "Unused today" isn't the same signal as "internal
+bookkeeping," so leave these as `@property()`.
+
+## Batching / order
+
+**Batch 0 - delete the no-ops (near zero risk, ~30 min).**
+`Et2DateTime.ts`, `Et2DateTimeOnly.ts`, `Et2DropdownButton.ts`, `RowLimitedMixin.ts` - their
+`static get properties()` adds nothing over `super.properties`; just remove the override. Good
+warm-up: proves the before/after `tsc`-diff workflow on trivial cases before anything else.
+
+**Batch 1 - leaf widgets, no collisions, has tests (~half a day).**
+`Et2DateRange`, `Et2DateReadonly`, `Et2DateSince`, `Et2ButtonTimestamper`, `Et2Switch`, `Et2Password`,
+`Et2Url`, `Et2InvokerMixin`, `Et2LinkSearch`, `Et2LinkList`, `CustomFilterHeader`, `ColumnSelection`,
+**`Et2Iframe`** (the file that started this - 7 props, no collision). Straightforward
+mechanical conversion; the existing test suite is the regression net.
+
+**Batch 2 - leaf widgets with a collision but test coverage (~half a day).**
+`Et2Date`, `Et2Link`, `Et2LinkAppSelect`, `ButtonMixin`. Apply the `noAccessor` idiom; tests still
+catch regressions.
+
+**Batch 3 - leaf widgets, no test coverage (~half a day, budget extra time for manual smoke tests).**
+`Et2AvatarGroup`, `Et2CheckboxReadonly`, `Et2Favorites`, `Et2Portlet`, `Et2Spinner`, `Et2Textarea`,
+`Et2SelectNumber`, `Et2SelectCountry`, `Et2TabPanel`, `Et2DescriptionExpose`, `ExposeMixin`,
+`Et2Description`. Manually exercise each widget in a real template (attribute set, JS set, readonly)
+per `widget-migration-status.md`'s convention, since there's no automated net.
+
+**Batch 4 - collision + no tests, the genuine highest-risk leaves (~half a day, write a
+characterization test first).**
+`Et2SelectState`, `Et2SelectReadonly`, `Et2Split`, `Layout/Et2Tabs/Et2Tabs`, `Et2Select.ts` itself
+(huge consumer set even though 0 own collisions).
+
+**Batch 5 - base classes, last (~1 day, wide manual smoke test).**
+`Et2InputWidget.ts`, then `Et2Widget.ts`. Highest value (102 tsc errors between them) and highest
+blast radius (every input widget / every widget respectively). Do only after Batches 1-4 have proven
+the workflow; smoke-test broadly across apps afterward (a form save/load in any app exercises most of
+`Et2Widget`'s properties).
+
+## Verification, per file or per batch
+
+1. `npm run typecheck 2>&1 | grep <file>` before/after - expect the file's own error count to hit 0
+   (every property it references now really exists) and no *new* errors elsewhere (a converted base
+   class can surface previously-hidden typos in subclasses - that's a real bug the migration found,
+   fix it, don't treat it as a migration failure).
+2. Run that widget's `test/*.test.ts` (`npx web-test-runner --group <name>` or the file directly) -
+   must stay green. `@property()` registers the same reactive property Lit already had, so a
+   passing suite before conversion should still pass after, except where §Risk item 1 applies.
+3. For the 19 files with no test directory, manual smoke test in a real template: set the property
+   via a `.xet` attribute, via JS (`widget.prop = x`), and check readonly rendering if applicable.
+4. Track the running total against the 4465-error baseline (same convention as
+   `et2select-searchmixin-removal.md`'s "60 → 117 tests" line) - expect roughly 744 fewer once all 40
+   `api/js/etemplate` files are done, modulo new errors surfaced per point 1.
+
+## Steps
+
+1. Batch 0 - delete the 4 no-op overrides.
+2. Batches 1-4 - convert leaf widgets and mixins, in the order above, one file (or tightly related
+   pair, e.g. the `Et2Date*` family) per commit, `tsc` + tests green before moving on.
+3. Batch 5 - `Et2InputWidget.ts`, then `Et2Widget.ts`, each as its own commit, wide smoke test after.
+4. Delete this doc once the table above is empty (`et2select-searchmixin-removal.md` convention).

--- a/doc/ai/projects/et2-style-extraction.md
+++ b/doc/ai/projects/et2-style-extraction.md
@@ -1,0 +1,130 @@
+# Et2* Widgets: Extract Large Inline `css\`...\`` Blocks to `.styles.ts`
+
+## Goal
+
+Every `Et2*`/webcomponent widget with more than **15 lines** of inline CSS in a `css\`...\`` tagged
+template literal (typically inside `static get styles()`/`static styles`) gets that block moved into
+its own companion `X.styles.ts` file, imported back in, matching the convention already used by 17
+files in the codebase (`Et2Datagrid.styles.ts`, `Et2File.styles.ts`, `Et2Toolbar.styles.ts`, etc.).
+Files at 15 lines or fewer stay inline - not worth the extra file for a handful of rules.
+
+This is a pure code-motion refactor, not a behaviour change: same `CSSResult`, same rules, just moved
+to keep large widget files from being dominated by CSS text. **Separate commit(s) from the
+[et2-property-decorator-migration.md](et2-property-decorator-migration.md) work** - unrelated concern,
+don't bundle the two even for files that need both.
+
+## Inventory
+
+**48 files** in `api/js/etemplate/` have inline `css\`...\`` blocks over 15 lines. Line counts are
+per-file totals (a few files have more than one `css\`` block, e.g. one in `styles` and one in a
+static helper - counted together). Extracted mechanically via a script counting lines between each
+`css\`` and its matching closing backtick, so treat as "roughly right," same caveat as the
+property-migration doc's own numbers.
+
+**20 of these 48 also appear in the property-decorator migration's file list** (marked below) - when a
+file needs both, do the CSS extraction as its own commit, either just before or just after that file's
+property conversion, so each diff stays reviewable as one thing.
+
+| File | CSS lines | Also in property migration? |
+|---|---|---|
+| Et2Select/Et2Select.ts | 171 | yes |
+| Et2Button/Et2ButtonToggle.ts | 132 | - |
+| Et2Select/SearchMixin.ts | 119 | - |
+| Layout/Et2Details/Et2Details.ts | 106 | - |
+| Et2Button/ButtonMixin.ts | 94 | yes |
+| Et2Dialog/Et2Dialog.ts | 77 | - |
+| Et2Link/Et2LinkList.ts | 74 | yes |
+| Et2Switch/Et2SwitchIcon.ts | 66 | - |
+| Et2Portlet/Et2Portlet.ts | 65 | yes |
+| Et2HtmlArea/Et2HtmlArea.ts | 64 | - |
+| Et2Widget/Et2Widget.ts | 64 | yes |
+| Layout/Et2Box/Et2Box.ts | 62 | - |
+| Et2Switch/Et2Switch.ts | 61 | yes |
+| Et2DropdownButton/Et2DropdownButton.ts | 59 | yes |
+| Et2Date/Et2DateDuration.ts | 55 | - |
+| Layout/Et2Groupbox/Et2Groupbox.ts | 53 | - |
+| Et2Select/Tag/Et2Tag.ts | 49 | - |
+| Et2Nextmatch/ColumnSelection.ts | 43 | yes |
+| Et2Select/Tag/Et2EmailTag.ts | 43 | - |
+| Et2Select/Et2Listbox.ts | 41 | - |
+| Et2Link/Et2Link.ts | 40 | yes |
+| Et2Customfields/Et2CustomfieldsList.ts | 39 | - |
+| Et2Date/Et2Date.ts | 36 | yes |
+| Et2Colorpicker/Et2Colorpicker.ts | 35 | - |
+| Layout/Et2Tabs/Et2Tabs.ts | 34 | yes |
+| Et2HtmlArea/Et2HtmlAreaReadonly.ts | 34 | - |
+| Et2Avatar/Et2Avatar.ts | 30 | - |
+| Et2Textbox/Et2Number.ts | 29 | - |
+| Et2Favorites/Et2FavoritesMenu.ts | 29 | - |
+| Et2Link/Et2LinkString.ts | 29 | - |
+| Et2Checkbox/Et2Checkbox.ts | 28 | - |
+| Et2Diff/Et2Diff.ts | 28 | - |
+| Et2Select/Select/Et2SelectCategory.ts | 27 | - |
+| Et2Favorites/Et2Favorites.ts | 26 | yes |
+| Et2Avatar/Et2AvatarGroup.ts | 25 | yes |
+| Et2Textarea/Et2Textarea.ts | 25 | yes |
+| Et2Description/Et2Description.ts | 24 | yes |
+| Et2Nextmatch/Headers/SortableHeader.ts | 24 | - |
+| Et2Url/Et2InvokerMixin.ts | 24 | yes |
+| Et2Customfields/Et2Customfields.ts | 23 | - |
+| Et2InputWidget/Et2InputWidget.ts | 23 | yes |
+| Et2Date/Et2DateTime.ts | 22 | yes *(also Batch 0 no-op delete there - unrelated reason)* |
+| Et2Link/Et2LinkTo.ts | 22 | - |
+| Et2Link/Et2LinkAdd.ts | 21 | - |
+| Et2Link/Et2LinkEntry.ts | 21 | - |
+| Et2Customfields/Et2CustomfieldsFilters.ts | 18 | - |
+| Layout/Et2Tabs/Et2TabPanel.ts | 17 | yes |
+| Et2Link/Et2LinkAppSelect.ts | 16 | yes |
+
+**Already correctly extracted** (17 files, not touched by this project): `Et2Ai.styles.ts`,
+`Et2Datagrid.styles.ts`, `Et2Email.styles.ts`, `Et2FileItem.styles.ts`, `Et2File.styles.ts`,
+`Et2Filterbox.styles.ts`, `Et2Nextmatch.row.styles.ts`, `Et2Nextmatch.styles.ts`,
+`Et2Template.styles.ts`, `Et2Toolbar.styles.ts`, `Et2TreeDropdown.styles.ts`, `Et2Tree.styles.ts`,
+`Et2VfsPath.styles.ts`, `Et2VfsSelectRow.styles.ts`, `Et2VfsSelect.styles.ts`,
+`Et2AppBox.styles.ts`, `Markdown.styles.ts`.
+
+**Naming inconsistency, not blocking, worth a follow-up rename:** `Et2Avatar/cropperStyles.ts`,
+`Et2Date/DateStyles.ts`, `Styles/colorsDefStyles.ts` are already separate style-only modules but don't
+follow the `X.styles.ts` companion-file naming convention (they predate it or serve multiple
+consumers). No content to extract, just a naming quirk - rename opportunistically if touching those
+areas, don't make it its own task.
+
+**Out of scope:** the dedicated style-library modules `Styles/bootstrap-icons.ts`,
+`Styles/shoelace.ts`, `Et2Styles/Et2Styles.ts` - these *are* CSS by design (icon font / vendor
+component styles), not a widget with an inline block to extract.
+
+## Batching / order
+
+No collision/base-class risk here like the property migration has - this is pure code motion, so
+ordering is mostly about commit-size hygiene rather than risk:
+
+1. **Biggest files first** (`Et2Select.ts` 171 lines down through the ~50-60 line range) - these are
+   the ones actually cluttering their host file, so highest value per commit.
+2. **The 20 files that overlap with the property-decorator migration** - sequence each one's CSS
+   extraction commit adjacent to (immediately before or after) that same file's property-conversion
+   commit, so anyone reviewing either project's commits sees a clean single-purpose diff, not a mix.
+3. **Remainder** (18-49 line files) - batch a handful per commit by directory/family (e.g. all the
+   `Et2Link/*` files together, all `Et2Select/Tag/*` together) since they're low-risk, mechanical, and
+   reviewing them one-by-one would be noise.
+
+## Verification, per file
+
+1. `npm run typecheck` - a pure move shouldn't introduce new errors; confirm count is unchanged for
+   that file.
+2. Run the widget's `test/*.test.ts` if it has one - moving CSS must not change computed styles/layout
+   the tests may assert on (e.g. visibility, computed dimensions).
+3. Manual smoke test for widgets with no test coverage: render the widget in a real template, confirm
+   it looks identical before/after (a quick visual diff is enough - this is a text move, not a rule
+   change).
+4. Grep the new `.styles.ts` file's export name against its host file's import to confirm nothing was
+   left duplicated inline (the `Et2Select.ts` leftover-registration bug found during the property
+   migration - see that doc's `@customElement` section - is a reminder that half-finished
+   extractions/migrations leave detectable dead code if not double-checked).
+
+## Steps
+
+1. Biggest-first, one file per commit, for the top ~10-15 files where the win is most visible.
+2. For the 20 overlap files, pair each with its property-decorator conversion commit (either order),
+   keeping the two commits adjacent and single-purpose.
+3. Batch the remaining files by directory/family, a handful per commit.
+4. Delete this doc once the table above is empty (`et2select-searchmixin-removal.md` convention).

--- a/mail/js/app.ts
+++ b/mail/js/app.ts
@@ -311,7 +311,7 @@ export class MailApp extends EgwApp
 				this.vacationFilterStatusChange();
 				break;
 			case 'mail.index':
-				this.getBodyIframe('messageIFRAME')?.addEventListener('load', () =>
+				this.et2?.getWidgetById('messageIFRAME')?.iframe?.addEventListener('load', () =>
 				{
 					// decrypt preview body if mailvelope is available
 					self.mailvelopeAvailable(self.mailvelopeDisplay);
@@ -427,7 +427,7 @@ export class MailApp extends EgwApp
 				// copies iframe content to a DIV, as iframe causes
 				// trouble for multipage printing
 
-				this.getBodyIframe('mailDisplayBodySrc')?.addEventListener('load', function(e)
+				this.et2?.getWidgetById('mailDisplayBodySrc')?.iframe?.addEventListener('load', function(e)
 				{
 					// encrypt body if mailvelope is available
 					self.mailvelopeAvailable(self.mailvelopeDisplay);
@@ -1830,7 +1830,7 @@ export class MailApp extends EgwApp
 					// body may have already finished loading (empty) before this resolved -
 					// retry the auto-index now that attachmentsBlock is known, but only into
 					// the iframe still actually showing this row (loadMessageBody() marks it)
-					const iframeDoc = this.getBodyIframe('messageIFRAME')?.contentDocument;
+					const iframeDoc = this.et2?.getWidgetById('messageIFRAME')?.iframe?.contentDocument;
 					if (iframeDoc?.documentElement?.dataset.rowId === rowId)
 					{
 						renderAttachmentIndex(iframeDoc, data.attachmentsBlock, this.egw);
@@ -2215,27 +2215,6 @@ export class MailApp extends EgwApp
 	 *  - routes through MailJmap.fetchBodyFromMessagePart() instead of fetchBody(), since a
 	 *  sub-part has no real, independently-addressable row-id of its own to fetch normally.
 	 */
-	/**
-	 * Get the real <iframe> DOM node for a mail body iframe widget
-	 *
-	 * Et2Iframe (the webcomponent, used since 2026-09-03) keeps its actual <iframe> inside a
-	 * shadow root - widget.getDOMNode() (inherited, unoverridden) returns the <et2-iframe> host
-	 * element instead, and a plain document.querySelector() can't pierce the shadow boundary
-	 * either. __getIframeNode() is Et2Iframe's own accessor for the real node. Falls back to
-	 * getDOMNode() for the legacy et2_iframe widget, where that already *is* the real iframe.
-	 */
-	private static realIframeNode(widget: any): HTMLIFrameElement
-	{
-		if(!widget) return null;
-		return (typeof widget.__getIframeNode === 'function' ? widget.__getIframeNode() : widget.getDOMNode()) || null;
-	}
-
-	/** Same as realIframeNode(), looked up by widget id against this.et2. */
-	private getBodyIframe(widgetId: string): HTMLIFrameElement
-	{
-		return MailApp.realIframeNode(this.et2?.getWidgetById(widgetId));
-	}
-
 	/** Shared by loadMessageBody()'s {special:true} result and its own catch() fallback below. */
 	private loadClassicBody(iframeWidget: any, iframe: HTMLIFrameElement, rowId: string, onLoad: (doc: Document) => void,
 		partID?: string): void
@@ -2257,7 +2236,7 @@ export class MailApp extends EgwApp
 	{
 		//we now fire the request so increase inFlight request by one
 		this.inFlightRequests += 1;
-		const iframe = MailApp.realIframeNode(iframeWidget);
+		const iframe = iframeWidget?.iframe;
 		const fetchPromise = partID ?
 			this.jmap.fetchBodyFromMessagePart(rowId, partID) :
 			this.jmap.fetchBody(rowId, undefined, signal, passphrase, passExpMinutes);
@@ -6892,7 +6871,7 @@ export class MailApp extends EgwApp
 	 */
 	preparePrint(_iframe?: HTMLIFrameElement)
 	{
-		const mainIframe = _iframe || this.getBodyIframe('mailDisplayBodySrc');
+		const mainIframe = _iframe || this.et2?.getWidgetById('mailDisplayBodySrc')?.iframe;
 		let tmpPrintDiv = document.body.querySelector('#tempPrintDiv');
 		let notAttached = false;
 
@@ -7005,7 +6984,7 @@ export class MailApp extends EgwApp
 	prepareMailvelopePrint()
 	{
 		const tempPrint = document.querySelector('div#tempPrintDiv') as HTMLElement;
-		const originFrame = this.getBodyIframe('mailDisplayBodySrc');
+		const originFrame = this.et2?.getWidgetById('mailDisplayBodySrc')?.iframe;
 
 		if (tempPrint)
 		{
@@ -7043,7 +7022,7 @@ export class MailApp extends EgwApp
 	mailvelopeDisplay(_keyring)
 	{
 		const self = this;
-		const iframe = this.getBodyIframe('mailDisplayBodySrc') || this.getBodyIframe('messageIFRAME');
+		const iframe = this.et2?.getWidgetById('mailDisplayBodySrc')?.iframe || this.et2?.getWidgetById('messageIFRAME')?.iframe;
 		const armored = iframe?.contentDocument?.querySelector('td.td_display > pre')?.textContent?.trim() || '';
 
 		if (armored == "" || armored.indexOf(this.begin_pgp_message) === -1) return;


### PR DESCRIPTION
## What

Adds mysql error code `1146` ("Table 'X' doesn't exist") to the list in `Db::query()` that gets wrapped as `Api\Db\Exception\InvalidSql` rather than plain `Api\Db\Exception`, and updates the `QuoteTest` classification tests that pinned the old behaviour.

## Why

A fresh install against an empty database aborts:

```
Database error: Table 'egroupware.egw_notificationpopup' doesn't exist (1146)
/var/www/egroupware/api/src/Db.php (863)
Installation failed --> exiting!
```

Reproduced independently on two clean databases via `egroupware/development:8.5`. It is invisible on any existing or upgraded instance, because the table is already there — it only bites genuinely fresh databases, i.e. new installs and CI.

The failing path is account creation, not the preferences hook the log's stderr interleaving suggests:

```
api/setup/default_records.inc.php:204  → setup->add_account()
setup/inc/class.setup.inc.php:1086     → Api\Accounts->save()
api/src/Accounts.php:879               → Api\Link::notify_update()
api/src/Link.php:1579                  → Api\Link::delete_cache()
api/src/Link.php:1748                  → new Json\Push(ALL) → Msg->call()
notifications/inc/class.notifications_push.inc.php:107 → INSERT egw_notificationpopup → 1146
```

`Push::checkSetBackend()` selects `notifications_push` on `class_exists()` alone, so the not-yet-installed app's backend is used — at that point only `admin`, `api`, `groupdav` and `preferences` are installed.

Both `Link::delete_cache()` and `notifications_push::addGeneric()` **already guard** that insert with `catch (Api\Db\Exception\InvalidSql $e)` — the latter added in ea740fa5b1, titled *"fix stalled installation caused by not (yet) existing egw_notificationspopup table"*, with a comment naming error 1146 explicitly. Neither ever fires: `InvalidSql` is a *subclass* of `Db\Exception`, so catching the narrower class misses a 1146 thrown as the broader one. `Api\Egw::__construct()`'s "is EGroupware set up yet, else redirect to setup" probe of `egw_config` (api/src/Egw.php:119) is broken the same way.

## Why fix the classification rather than the three catch sites

The non-mysqli branch of the very same method — `if (!$rs)`, api/src/Db.php:892 — raises `InvalidSql` for **every** SQL error regardless of code. So postgres was never affected; mysqli under PHP 8.1+ is the outlier, and any future `catch (InvalidSql)` written against postgres would silently misbehave on mysqli. `1054` "Unknown column" is already in the list and `1146` "Unknown table" is its structural twin.

Because `InvalidSql extends Db\Exception`, the change can only widen what existing `catch` blocks see, never narrow it — no caller that currently handles 1146 stops handling it.

## Test change

`QuoteTest::testQueryUnknownTableThrowsGenericDbExceptionNotInvalidSql` (added the same day in 38e19c288d) is a characterization test that picked 1146 arbitrarily as its "code not in the list" example; it asserted an incidental fact, not a requirement. It now asserts 1146 **is** `InvalidSql`, with the reasoning in the docblock, and a new sibling test covers the generic-`Db\Exception` side using 1136 "Column count doesn't match value count" — a parse-level error, so it is stable regardless of `egw_test`'s schema.

## Verification

Reproduced and fixed against a throwaway database in a docker instance (a second, additive `test` domain in `header.inc.php`, leaving `default` untouched):

- **Before:** `Database error: Table 'egwtest.egw_notificationpopup' doesn't exist (1146)` → `Installation failed`
- **After:** `Installation finished.` — 31 apps, 104 tables; `setup-cli.php --admin` then created the `sysop` account successfully
- `api/tests/Db/` — identical failure set to the pre-change baseline (all pre-existing and environmental: that dev DB's `egw_test` schema is older than the checkout's), plus the one new passing test

## Notes for the reviewer

Two related problems found while diagnosing this, both **out of scope here**:

1. **`doc/docker/development/entrypoint.sh` serves a half-installed instance.** Its retry loop's success condition is `-f header.inc.php`, but `post_install.php` writes header.inc.php *before* running the install — so after one failed attempt the condition is true, the loop exits without retrying and without printing "Installing of EGroupware failed!", and `exec php-fpm` starts anyway. The `[ "$(tail -1 $LOG)" = "Installing of EGroupware failed!" ] && exit 1` guard below it could not fire regardless: `set -ex` means the log's last line is always a `+ …` trace line. `doc/docker/fpm/entrypoint.sh:110` has the equivalent guard commented out entirely. Net effect: the failure reads as success — HTTP 200 and a normal-looking login page over a 4-app/31-table install with no user accounts.

2. **`scanForWidgets()` is not re-entrancy-safe.** `api/src/Etemplate/Widget.php` calls `Widget::scanForWidgets()` at the bottom of the file. When the first etemplate class autoloaded is a *subclass* (e.g. `Widget\HtmlArea`), Widget.php loads as part of resolving the parent, so the scan runs while HtmlArea.php is still mid-include; `registerWidget()` at the bottom of HtmlArea.php has not run yet, the scan's own sanity check fails, and the widget registry is left incomplete **and never cached**. Every install logs `scanForWidgets() wrong class for Htmlarea` because of this. Worth checking whether it also hits ordinary web requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
