### PR TITLE
mail: fix three JMAP-lite REST bugs found by live verification

### DIFF
--- a/api/src/Jmap/Type.php
+++ b/api/src/Jmap/Type.php
@@ -38,9 +38,15 @@ abstract class Type
 	 *  every text/html body part's value in the response's bodyValues, not just ones explicitly
 	 *  referenced. Meaningless for any other type - never pass true except for Email, since a
 	 *  real JMAP server may reject an argument its method doesn't define.
+	 * @param string|null $mailboxId NON-standard, JmapShim-only: the mailbox the ids live in.
+	 *  Api\Mail\Jmap\Imap::emailGet() needs a mailbox to FETCH from and otherwise relies on the
+	 *  context a preceding Email/query left behind, so a standalone Email/get (one email by id,
+	 *  no listing first) has to say which mailbox itself. RFC 8620 §3.6.1 makes a real JMAP
+	 *  server reject arguments its method does not define, so callers must only pass this for
+	 *  shim-backed sessions - see Mail\ApiHandler::isRealJmapSession().
 	 * @return array{list: array[], notFound?: string[]}
 	 */
-	public function get(?array $ids=null, ?array $properties=null, bool $fetchAllBodyValues=false) : array
+	public function get(?array $ids=null, ?array $properties=null, bool $fetchAllBodyValues=false, ?string $mailboxId=null) : array
 	{
 		return $this->jmap->call(static::TYPE_NAME.'/get', array_filter([
 			// RFC 8620 §5.1: every standard method call requires accountId - both concrete
@@ -49,6 +55,7 @@ abstract class Type
 			'ids' => $ids,
 			'properties' => $properties,
 			'fetchAllBodyValues' => $fetchAllBodyValues ?: null,
+			'mailboxId' => $mailboxId,
 		], static fn($v) => $v !== null));
 	}
 

--- a/api/src/Mail/Jmap/Imap/Email.php
+++ b/api/src/Mail/Jmap/Imap/Email.php
@@ -27,14 +27,19 @@ class Email extends Base
 	 * $fetchAllBodyValues is unused - Imap::emailGet() already always populates bodyValues in
 	 * full whenever any body property is requested (no partial-fetch mode to opt into, unlike a
 	 * real JMAP server).
+	 *
+	 * $mailboxId is forwarded: emailGet() takes it as the alternative to the mailbox context a
+	 * preceding emailQuery() would have left in $jmap->context, which is what makes a standalone
+	 * Email/get (no listing first) possible at all - without either, it throws.
 	 */
-	public function get(?array $ids=null, ?array $properties=null, bool $fetchAllBodyValues=false) : array
+	public function get(?array $ids=null, ?array $properties=null, bool $fetchAllBodyValues=false, ?string $mailboxId=null) : array
 	{
 		/** @var Imap $jmap */
 		$jmap = $this->jmap;
 		return Imap::emailGet($jmap->accountId, array_filter([
 			'ids' => $ids,
 			'properties' => $properties,
+			'mailboxId' => $mailboxId,
 		], static fn($v) => $v !== null), $jmap->context);
 	}
 

--- a/api/src/Mail/Jmap/Imap/Mailbox.php
+++ b/api/src/Mail/Jmap/Imap/Mailbox.php
@@ -21,10 +21,12 @@ use EGroupware\Api\Mail\Jmap\Imap;
 class Mailbox extends Base
 {
 	/**
-	 * $properties/$fetchAllBodyValues are unused - mailboxGet() has no properties-filter or
-	 * body-value concept (Mailbox has no body).
+	 * $properties/$fetchAllBodyValues/$mailboxId are unused - mailboxGet() has no
+	 * properties-filter or body-value concept (Mailbox has no body), and a Mailbox is
+	 * addressed by its own id, so it never needs one to be told which mailbox it is in.
+	 * $mailboxId is only in the signature to stay LSP-compatible with Api\Jmap\Type::get().
 	 */
-	public function get(?array $ids=null, ?array $properties=null, bool $fetchAllBodyValues=false) : array
+	public function get(?array $ids=null, ?array $properties=null, bool $fetchAllBodyValues=false, ?string $mailboxId=null) : array
 	{
 		/** @var Imap $jmap */
 		$jmap = $this->jmap;

--- a/mail/src/ApiHandler.php
+++ b/mail/src/ApiHandler.php
@@ -975,7 +975,7 @@ class ApiHandler extends Api\CalDAV\Handler
 	 * @param int|null $ident_id
 	 * @return true
 	 */
-	protected static function listFolders(int $user, ?int $ident_id) : bool
+	protected static function listFolders(int $user, ?int $ident_id) : string
 	{
 		$account = self::getMailAccount($user, $ident_id);
 		$session = $account->jmapSession();
@@ -989,7 +989,7 @@ class ApiHandler extends Api\CalDAV\Handler
 			$responses[$prefix.$mailbox['id']] = $mailbox;
 		}
 		echo json_encode(['responses' => $responses], self::JSON_RESPONSE_OPTIONS);
-		return true;
+		return '200 Ok';
 	}
 
 	/**
@@ -998,10 +998,12 @@ class ApiHandler extends Api\CalDAV\Handler
 	 * @param int $user
 	 * @param int|null $ident_id
 	 * @param string $folderIdUrlSafe
-	 * @return true
+	 * @return string HTTP status - NOT true: HTTP_WebDAV_Server only keeps the
+	 *  Content-Type the handler set when the GET handler returns a status string;
+	 *  returning true makes it default the body to application/octet-stream
 	 * @throws \Exception (404) if not found
 	 */
-	protected static function getFolder(int $user, ?int $ident_id, string $folderIdUrlSafe) : bool
+	protected static function getFolder(int $user, ?int $ident_id, string $folderIdUrlSafe) : string
 	{
 		$account = self::getMailAccount($user, $ident_id);
 		$session = $account->jmapSession();
@@ -1014,7 +1016,7 @@ class ApiHandler extends Api\CalDAV\Handler
 			throw new \Exception("Folder '$folderIdUrlSafe' not found", 404);
 		}
 		echo json_encode(self::jsonMailbox($list[0]), self::JSON_RESPONSE_OPTIONS);
-		return true;
+		return '200 Ok';
 	}
 
 	/**
@@ -1023,9 +1025,11 @@ class ApiHandler extends Api\CalDAV\Handler
 	 * @param int $user
 	 * @param int|null $ident_id
 	 * @param string $folderIdUrlSafe
-	 * @return true
+	 * @return string HTTP status - NOT true: HTTP_WebDAV_Server only keeps the
+	 *  Content-Type the handler set when the GET handler returns a status string;
+	 *  returning true makes it default the body to application/octet-stream
 	 */
-	protected static function listEmails(int $user, ?int $ident_id, string $folderIdUrlSafe) : bool
+	protected static function listEmails(int $user, ?int $ident_id, string $folderIdUrlSafe) : string
 	{
 		$account = self::getMailAccount($user, $ident_id);
 		$session = $account->jmapSession();
@@ -1064,7 +1068,7 @@ class ApiHandler extends Api\CalDAV\Handler
 			'position' => $query['position'] ?? $position,
 			'total' => $query['total'] ?? count($ids),
 		], self::JSON_RESPONSE_OPTIONS);
-		return true;
+		return '200 Ok';
 	}
 
 	/**
@@ -1072,26 +1076,33 @@ class ApiHandler extends Api\CalDAV\Handler
 	 *
 	 * @param int $user
 	 * @param int|null $ident_id
-	 * @param string $folderIdUrlSafe unused beyond routing/discoverability - Email/get only needs
-	 *  the emailId (see doc/ai/projects/mail-rest-jmap-lite.md's attachment-endpoint note, same
-	 *  reasoning)
+	 * @param string $folderIdUrlSafe the mailbox to read the email from. A real JMAP server
+	 *  identifies an Email by id alone, but the JmapShim has to FETCH it out of some IMAP
+	 *  mailbox: Api\Mail\Jmap\Imap::emailGet() otherwise relies on the context a preceding
+	 *  Email/query left behind, and this endpoint has no listing in front of it, so it must
+	 *  pass the mailbox explicitly or the shim throws. Only for shim sessions - RFC 8620
+	 *  §3.6.1 lets a real JMAP server reject an argument Email/get does not define.
 	 * @param string $emailId
-	 * @return true
+	 * @return string HTTP status - NOT true: HTTP_WebDAV_Server only keeps the
+	 *  Content-Type the handler set when the GET handler returns a status string;
+	 *  returning true makes it default the body to application/octet-stream
 	 * @throws \Exception (404) if not found
 	 */
-	protected static function getEmail(int $user, ?int $ident_id, string $folderIdUrlSafe, string $emailId) : bool
+	protected static function getEmail(int $user, ?int $ident_id, string $folderIdUrlSafe, string $emailId) : string
 	{
 		$account = self::getMailAccount($user, $ident_id);
 		$session = $account->jmapSession();
+		// only the local JmapShim's own ids need decoding back - see fromUrlSafeId()'s docblock
+		$mailboxId = self::isRealJmapSession($session) ? null : self::fromUrlSafeId($folderIdUrlSafe);
 
 		$properties = self::queryProperties() ?? array_merge(self::DEFAULT_EMAIL_LIST_PROPERTIES, self::DEFAULT_EMAIL_BODY_PROPERTIES);
-		$list = $session->email->get([$emailId], $properties, true)['list'] ?? [];
+		$list = $session->email->get([$emailId], $properties, true, $mailboxId)['list'] ?? [];
 		if (!$list)
 		{
 			throw new \Exception("Email '$emailId' not found", 404);
 		}
 		echo json_encode(self::jsonEmail($list[0]), self::JSON_RESPONSE_OPTIONS);
-		return true;
+		return '200 Ok';
 	}
 
 	/**
@@ -1109,10 +1120,12 @@ class ApiHandler extends Api\CalDAV\Handler
 	 * @param string $folderIdUrlSafe
 	 * @param string $emailId
 	 * @param string $blobId
-	 * @return true
+	 * @return string HTTP status - NOT true: HTTP_WebDAV_Server only keeps the
+	 *  Content-Type the handler set when the GET handler returns a status string;
+	 *  returning true makes it default the body to application/octet-stream
 	 * @throws \Exception (404) if not found
 	 */
-	protected static function getAttachment(int $user, ?int $ident_id, string $folderIdUrlSafe, string $emailId, string $blobId) : bool
+	protected static function getAttachment(int $user, ?int $ident_id, string $folderIdUrlSafe, string $emailId, string $blobId) : string
 	{
 		$account = self::getMailAccount($user, $ident_id);
 		$bytes = Ui\AttachmentJmap::fetchBlobBytes((string)$account->acc_id, $blobId);
@@ -1123,7 +1136,11 @@ class ApiHandler extends Api\CalDAV\Handler
 		$name = $blobId;
 		$type = '';
 		try {
-			$email = $account->jmapSession()->email->get([$emailId], ['attachments'])['list'][0] ?? null;
+			$session = $account->jmapSession();
+			// same mailbox-context requirement as getEmail() - without it the shim throws and the
+			// catch below silently degrades every download to blobId/octet-stream
+			$mailboxId = self::isRealJmapSession($session) ? null : self::fromUrlSafeId($folderIdUrlSafe);
+			$email = $session->email->get([$emailId], ['attachments'], false, $mailboxId)['list'][0] ?? null;
 			foreach ((array)($email['attachments'] ?? []) as $attachment)
 			{
 				if (($attachment['blobId'] ?? null) === $blobId)
@@ -1139,7 +1156,7 @@ class ApiHandler extends Api\CalDAV\Handler
 		}
 		Api\Header\Content::type($name, $type, strlen($bytes));
 		echo $bytes;
-		return true;
+		return '200 Ok';
 	}
 
 	const PASSWORD_DUMMY = '********';

--- a/mail/tests/ApiHandlerJmapRestTest.php
+++ b/mail/tests/ApiHandlerJmapRestTest.php
@@ -319,7 +319,7 @@ class FakeJmapMailboxForFolderWalk extends JmapType
 		return ['ids' => $ids];
 	}
 
-	public function get(?array $ids=null, ?array $properties=null, bool $fetchAllBodyValues=false) : array
+	public function get(?array $ids=null, ?array $properties=null, bool $fetchAllBodyValues=false, ?string $mailboxId=null) : array
 	{
 		return ['list' => array_values(array_intersect_key(self::TREE, array_flip((array)$ids)))];
 	}


### PR DESCRIPTION
Three bugs in the JMAP-lite mail REST endpoints from 6fd81c88, found by doing the live
verification that commit's own doc lists as still pending.

`doc/ai/projects/mail-rest-jmap-lite.md` says:

> **Not done yet / explicitly deferred**: Live REST-level verification against a running
> instance […] not run in this session.

Running it against a plain-IMAP account (so the `Api\Mail\Jmap\Imap` / JmapShim path) turned up
three problems. None of them is reachable from a unit test: two need a live IMAP session, the
third is an HTTP response header.

### 1. `GET …/folders/<folderId>/emails/<emailId>` was a hard 500

```json
{"error":500,"message":"Email/get without a preceding Email/query or a mailboxId for the same accountId in this request"}
```

`getEmail()` calls `$session->email->get()` with no mailbox. `Imap::emailGet()` needs either a
preceding `Email/query` in the same request or an explicit `mailboxId` — and the folder id was
already sitting in the URL, the method just declared it *"unused beyond routing/discoverability"*.
`listEmails()` only works because its `Email/query` leaves the mailbox in the shim's context.

`Api\Jmap\Type::get()` gains an optional `$mailboxId` (the shim's `Email`/`Mailbox` overrides
widened to match for LSP), and `ApiHandler` passes the decoded folder id — gated on the existing
`isRealJmapSession()` so a real JMAP server never receives an argument RFC 8620 §3.6.1 lets it
reject.

### 2. Attachment downloads lost their filename and content type

Every download came back as `Content-Disposition: attachment; filename="SU5CT1g:9:2"` with
`application/octet-stream`. `getAttachment()` resolves the real name/type through the same
`email->get()`, inside a `catch (\Throwable)` that degrades silently — so bug 1 was invisible
there and simply disabled the lookup. Same fix; now `crash-log.pdf` / `application/pdf`.

### 3. All five endpoints answered `Content-Type: application/octet-stream`

`get()` does set `application/json`, but the handlers `return true`, and `HTTP_WebDAV_Server`
then overrides it. `CalDAV.php:1478` documents the idiom:

> `// as not mimetype is set, GET handler will use application/octet-stream, returning 200 Ok avoids that`

Every pre-existing REST endpoint (`/mail`, `/mail/<id>`, `/tracker/`, …) returns
`application/json; charset=utf-8`. A real client does notice: an n8n HTTP node filed the response
as a binary file download and the workflow read no mail at all. All five handlers now return a
status string.

## Verification

Live, against a running instance with a GreenMail (plain IMAP → JmapShim) account:

| | before | after |
|---|---|---|
| `GET /mail/2/folders` | 200, `octet-stream` | 200, `application/json` |
| `GET …/folders/<id>` | 200, `octet-stream` | 200, `application/json` |
| `GET …/emails` | 200, `octet-stream` | 200, `application/json` |
| `GET …/emails/<id>` | **500** | 200, `application/json`, with `bodyValues` |
| `GET …/attachments/<blobId>` | 200, `octet-stream`, filename = blobId | 200, `application/pdf`, `crash-log.pdf` |

Also exercised: the folder tree, paging (`position` / `total` / `limit`), `filter[text]`, an
invalid filter correctly 400ing, and a full attachment round trip (bytes identical).

Two things that doc flags as *"specifically worth checking live"* are confirmed as no-ops on the
shim: **`filter[hasAttachment]`** and **`filter[after]`** each return the whole mailbox —
`after` even for a timestamp in the future. Not touched here, but worth knowing before a client
relies on them.

**Real JMAP / Stalwart remains unverified** — I only had a plain-IMAP account. The `mailboxId`
argument is gated so it is never sent to a real JMAP server, but a second pair of eyes on that
path would be welcome.

`mail/tests/ApiHandlerJmapRestTest` stays at 18/19; the 19th
(`testEmailFromFetchPopulatesMailboxIdsForANonInboxFolder`) wants a database and fails
identically with and without this change.
