### PR TITLE
Mail: attaching VFS files into an already-open compose popup hung it …

### DIFF
--- a/addressbook/js/app.ts
+++ b/addressbook/js/app.ts
@@ -1118,7 +1118,7 @@ class AddressbookApp extends EgwApp
 	adb_mail_vcard(_action, _elems)
 	{
 		const link = {'preset[type]':[], 'preset[file]':[]};
-		const content = {data:{files:{file:[], type:[]}}};
+		const content = {data:{files:{file:[], type:[], name:[]}}};
 		const vcardType = "text/vcard; charset="+(egw.preference('vcard_charset', 'addressbook') || 'utf-8');
 		const nm = this.et2.getWidgetById('nm');
 		if(this._fetchAllSelected(nm, (ids) =>
@@ -1148,6 +1148,10 @@ class AddressbookApp extends EgwApp
 			content.data.files.type.push(vcardType);
 			const contactName = egw.dataGetUIDdata(_elems[i].id)?.data?.n_fn;
 			files.push({path, name: (contactName || 'vcard') + '.vcf', type: vcardType});
+			// same name for the "reuse an already-open popup" case, which MailApp.setCompose()
+			// resolves client-side too (vfsFilesFromComposeContent()) - a bare ".entry" basename
+			// is no attachment name
+			content.data.files.name.push(files[files.length - 1].name);
 		}
 		// Matches an already-open compose popup's own url (mail/compose.php,
 		// doc/ai/projects/mail-compose-jmap-migration.md Step 10) - MailApp.setCompose() only ever

--- a/filemanager/js/filemanager.ts
+++ b/filemanager/js/filemanager.ts
@@ -540,6 +540,11 @@ export class filemanagerAPP extends EgwApp
 			});
 		}
 		content.data.files["filemode"] = params['preset[filemode]'];
+		// the same name/type for the "reuse an already-open popup" case: MailApp.setCompose()
+		// resolves that client-side too (vfsFilesFromComposeContent()), and the type is what the
+		// JMAP upload declares at send time
+		content.data.files["name"] = files.map(f => f.name);
+		content.data.files["type"] = files.map(f => f.type);
 		// always open compose in html mode, as attachment links look a lot nicer in html
 		params["mimeType"] = 'html';
 		// Matches an already-open compose popup's own url (mail/compose.php,

--- a/mail/js/app.ts
+++ b/mail/js/app.ts
@@ -1915,6 +1915,13 @@ export class MailApp extends EgwApp
 		{
 			(<any>window).app._compose.applyPresetFiles(preset.files);
 		}
+		// contentCopy.filemode above only preselects the widget - a "send as link/share" the user
+		// picked in filemanager has to count as their explicit choice too, or the send would
+		// silently attach the files anyway (MailCompose.applyPresetFilemode()'s own docblock)
+		if (preset?.filemode)
+		{
+			(<any>window).app._compose.applyPresetFilemode(preset.filemode);
+		}
 		if (preset?.attachmentContents?.length)
 		{
 			await (<any>window).app._compose.applyPresetAttachmentContent(preset.attachmentContents);
@@ -1931,6 +1938,24 @@ export class MailApp extends EgwApp
 		{
 			this.egw.message(preset.msg, 'info');
 		}
+	}
+
+	/**
+	 * The {path, name, type}[] MailCompose.applyPresetFiles() wants, from setCompose()'s classic
+	 * `content.data.files` shape: parallel arrays `file` (vfs://default/... paths, required) and
+	 * optional `name`/`type` (same index). A missing name falls back to the path's basename, a
+	 * missing type to application/octet-stream - the type is what the JMAP upload at send time
+	 * declares, so callers that know the real mime (filemanager's row cache, a mail attachment's
+	 * own part) pass it along.
+	 */
+	vfsFilesFromComposeContent(files : any) : { path : string, name : string, type : string }[]
+	{
+		const paths : string[] = Array.isArray(files?.file) ? files.file : [];
+		return paths.filter(Boolean).map((path, i) => ({
+			path,
+			name: files.name?.[i] || path.split('/').pop() || path,
+			type: files.type?.[i] || 'application/octet-stream',
+		}));
 	}
 
 	/**
@@ -1985,9 +2010,43 @@ export class MailApp extends EgwApp
 						this.compose.mergeForwardAttachments(String(ids).split(',').filter(Boolean));
 						return true;
 					}
+					// VFS files (filemanager "attach to mail", addressbook vCard-attach, a mail
+					// attachment re-attached via ajax_vfsOpen): the other content shape reachable
+					// while a popup is already open. Found live 2026-09-10: it fell through to the
+					// classic appendix_data+submit() postback below, which the client-side compose
+					// (mail/compose.php) has nothing to answer - the popup sat on its "please wait"
+					// prompt for ever, no request even left. Same bare jmapVfsPath marker rows the
+					// "nothing to reuse" path builds via composeWithPreset({files}), through the same
+					// MailCompose.applyPresetFiles().
+					const vfsFiles = this.vfsFilesFromComposeContent(content[field]?.['files']);
+					const filemode = compose_et2[0].widgetContainer.getWidgetById('filemode');
+					if (vfsFiles.length && this.compose.isJmapModeActive)
+					{
+						const wanted = content[field]['files']['filemode'];
+						if (wanted && filemode && filemode.get_value() != wanted)
+						{
+							const filemode_label = (filemode.select_options || []).filter(_item => _item.value == wanted)[0]?.['label'] || wanted;
+							Et2Dialog.show_dialog((_button) =>
+								{
+									if (_button == Et2Dialog.YES_BUTTON)
+									{
+										// the confirmed answer IS the explicit share-mode choice the send path
+										// requires - a bare filemode.set_value() would not count
+										this.compose.applyPresetFilemode(wanted);
+										this.compose.applyPresetFiles(vfsFiles);
+									}
+								},
+								this.egw.lang(
+									'Be aware by adding all selected files as %1 mode, it will also change all existing attachments in the list to %2 mode as well. Would you like to proceed?',
+									filemode_label, filemode_label),
+								this.egw.lang('Add files as %1', filemode_label), {}, Et2Dialog.BUTTONS_YES_NO, Et2Dialog.WARNING_MESSAGE);
+							return true;
+						}
+						this.compose.applyPresetFiles(vfsFiles);
+						return true;
+					}
 					const w = compose_et2[0].widgetContainer.getWidgetById('appendix_data');
 					w.set_value(JSON.stringify(content[field]));
-					const filemode = compose_et2[0].widgetContainer.getWidgetById('filemode');
 					if (content[field]['files'] && content[field]['files']['filemode']
 							&& filemode && filemode.get_value() != content[field]['files']['filemode'])
 					{
@@ -5634,6 +5693,10 @@ export class MailApp extends EgwApp
 							name: attachments[row_id].filename,
 							type: attachments[row_id].type || 'application/octet-stream',
 						}];
+						// the same name/type for the "reuse an already-open popup" case, which
+						// setCompose() resolves client-side too (vfsFilesFromComposeContent())
+						content.data.files["name"] = files.map(f => f.name);
+						content.data.files["type"] = files.map(f => f.type);
 						egw.openWithinWindow("mail", "setCompose", content, params, COMPOSE_POPUP_URL_PATTERN, true,
 							() => this.composeWithPreset({files, mimeType: 'html'}));
 					})

--- a/mail/js/compose.ts
+++ b/mail/js/compose.ts
@@ -448,6 +448,42 @@ export class MailCompose
 	}
 
 	/**
+	 * Apply a caller-chosen "send files as" mode (filemanager's Download link / Readonly share /
+	 * Writable share actions, via composeWithPreset({filemode}) for a fresh popup or
+	 * MailApp.setCompose()'s own confirmed yes/no question for an already-open one) the way a real
+	 * user pick through the widget counts: currentEmailFields() only ever converts attachments
+	 * into share links when `explicitShareModeChosen` is set (see its docblock), and a
+	 * programmatic set_value() does NOT set it - checkSharingFilemode()'s genuine-onchange branch
+	 * never sees a node for it (found live 2026-09-10: widget said "link", the send would still
+	 * have attached the files). The user picked the mode in the other app and, for an open popup,
+	 * confirmed it - that is the explicit choice. Also runs checkSharingFilemode()'s load-time
+	 * variant so the expiration/password fields follow the mode, without its extra alert.
+	 *
+	 * @param filemode 'attach' | 'link' | 'share_ro' | 'share_rw'
+	 */
+	public applyPresetFilemode(filemode : string) : void
+	{
+		const widget = this.et2?.getWidgetById('filemode');
+		if (!filemode || !widget) return;
+		if (widget.get_value() !== filemode)
+		{
+			widget.set_value(filemode);
+		}
+		this.checkSharingFilemode(undefined, widget);
+		// checkSharingFilemode() may have downgraded share_rw without EPL - read back the value
+		this.explicitShareModeChosen = widget.get_value() !== 'attach';
+	}
+
+	/**
+	 * Strip the "vfs://default" url prefix a preset file path may carry, leaving the bare absolute
+	 * VFS path the jmapVfsPath marker rows (and everything consuming them) work with.
+	 */
+	public static vfsPathFromPreset(path : string) : string
+	{
+		return String(path || '').replace(/^vfs:\/\/default(?=\/)/, '');
+	}
+
+	/**
 	 * Apply a client-side-only compose bootstrap's own preset VFS-attachment files (addressbook
 	 * vCard-attach, filemanager "mail selected files" - doc/ai/projects/mail-compose-jmap-
 	 * migration.md, Step 10) - same bare `jmapVfsPath` marker shape vfsUpload() itself builds for
@@ -464,7 +500,13 @@ export class MailCompose
 		if (!files.length) return;
 		this.mergeAttachmentEntries(files.map((f) => ({
 			tmp_name: 'vfs:' + f.path,
-			jmapVfsPath: f.path,
+			// a bare absolute VFS path ("/home/asig/x.pdf"), never the "vfs://default/..." url the
+			// classic preset[file] params carry (filemanager, addressbook, mail re-attach and 3rd-party
+			// callers all build that one): every consumer of the marker prepends the prefix itself
+			// (Compose::resolveJmapAttachmentsToFiles() Vfs::PREFIX, displayUploadedFile()'s and
+			// uploadVfsAttachment()'s webdav.php url) - the url form died at send time with
+			// "Filename 'vfs://default/...' is not an absolute path!" (found live 2026-09-10)
+			jmapVfsPath: MailCompose.vfsPathFromPreset(f.path),
 			name: f.name || f.path.split('/').pop() || f.path,
 			type: f.type || 'application/octet-stream',
 			size: 0,

--- a/mail/js/test/MailAppSetComposeVfsFiles.test.ts
+++ b/mail/js/test/MailAppSetComposeVfsFiles.test.ts
@@ -1,0 +1,174 @@
+import {assert} from "@open-wc/testing";
+import * as sinon from "sinon";
+import "./MailAppImportStub";
+// breaks the et2_core_widget <-> Et2Widget import cycle (ClassWithAttributes TDZ) the same
+// way the other mail app.ts tests do, before app.ts pulls it in transitively
+import "../../../api/js/etemplate/Et2Widget/Et2Widget";
+import type {MailApp} from "../app";
+import {Et2Dialog} from "../../../api/js/etemplate/Et2Dialog/Et2Dialog";
+
+// see ComposeMessageAccId.test.ts for why app.ts is loaded through its explicit source path
+const APP_SOURCE = '/mail/js/app.ts';
+
+/**
+ * Regression coverage for a real report (2026-09-10): filemanager "share -> mail -> attach" into
+ * an ALREADY-OPEN compose popup (egw.openWithinWindow()'s "Select an opened dialog" chooser
+ * calling MailApp.setCompose()) hung that popup on its "please wait" prompt for ever.
+ *
+ * setCompose() only handled the forward-as-attachment content shape ({data:{emails:{ids}}})
+ * client-side; the VFS-files shape ({data:{files:{file:[...]}}} - filemanager, addressbook
+ * vCard-attach, a mail attachment re-attached via ajax_vfsOpen) fell through to the classic
+ * appendix_data + submit() postback, which the client-side compose (mail/compose.php) has nothing
+ * to answer. In JMAP mode the files must go through MailCompose.applyPresetFiles(), the same
+ * jmapVfsPath-marker route composeWithPreset({files}) takes for a fresh popup.
+ *
+ * Setup: setCompose() only touches `this.compose` and the compose window's etemplate2, so the
+ * app object is a bare Object.create(MailApp.prototype), the window a hand-built stub.
+ */
+describe('MailApp.setCompose() with VFS files', () =>
+{
+	let MailAppClass : typeof MailApp;
+	let app : MailApp;
+	let compose : any;
+	let submit : sinon.SinonSpy;
+	let appendix : {set_value : sinon.SinonSpy};
+	let filemode : any;
+	let composeWindow : any;
+
+	before(async function()
+	{
+		this.timeout(15000);
+		MailAppClass = (await import(APP_SOURCE)).MailApp;
+	});
+
+	beforeEach(() =>
+	{
+		(<any>window).egw = {preference: () => '', lang: (s : string) => s, debug: () => {}};
+		submit = sinon.spy();
+		appendix = {set_value: sinon.spy()};
+		filemode = {get_value: () => 'attach', set_value: sinon.spy(), select_options: [
+			{value: 'attach', label: 'Attachment'}, {value: 'link', label: 'Download link'},
+		]};
+		const widgets : any = {appendix_data: appendix, filemode};
+		composeWindow = {
+			closed: false,
+			etemplate2: {getByApplication: () => [{
+				widgetContainer: {
+					getWidgetById: (id : string) => widgets[id],
+					getInstanceManager: () => ({submit}),
+				},
+				submit,
+			}]},
+		};
+		compose = {isJmapModeActive: true, applyPresetFiles: sinon.spy(), applyPresetFilemode: sinon.spy(), mergeForwardAttachments: sinon.spy()};
+
+		app = Object.create(MailAppClass.prototype);
+		Object.assign(app, {appname: 'mail', egw: (<any>window).egw});
+		// MailApp.compose is a prototype getter over the loaded etemplate - shadow it
+		Object.defineProperty(app, 'compose', {value: compose, configurable: true});
+	});
+
+	it('merges the files client-side in JMAP mode, never through the classic postback', () =>
+	{
+		const result = app.setCompose(composeWindow, {data: {files: {
+			file: ['vfs://default/home/asig/certs/pw_atza_cert.odt'],
+			name: ['pw_atza_cert.odt'],
+			type: ['application/vnd.oasis.opendocument.text'],
+			filemode: 'attach',
+		}}});
+
+		assert.isTrue(result);
+		assert.isTrue(compose.applyPresetFiles.calledOnce);
+		assert.deepEqual(compose.applyPresetFiles.firstCall.args[0], [{
+			path: 'vfs://default/home/asig/certs/pw_atza_cert.odt',
+			name: 'pw_atza_cert.odt',
+			type: 'application/vnd.oasis.opendocument.text',
+		}]);
+		// the hang: submit() had nothing to talk to
+		assert.isFalse(submit.called, 'no classic postback');
+		assert.isFalse(appendix.set_value.called, 'appendix_data untouched');
+	});
+
+	it('asks before switching the filemode, then applies the mode as an explicit choice plus the files', () =>
+	{
+		const showDialog = sinon.stub(Et2Dialog, 'show_dialog');
+		try
+		{
+			const result = app.setCompose(composeWindow, {data: {files: {file: ['vfs://default/home/asig/a.pdf'], filemode: 'link'}}});
+
+			assert.isTrue(result);
+			assert.isTrue(showDialog.calledOnce, 'the yes/no question');
+			assert.isFalse(compose.applyPresetFiles.called, 'nothing merged before the answer');
+			assert.isFalse(submit.called);
+
+			showDialog.firstCall.args[0](Et2Dialog.NO_BUTTON);
+			assert.isFalse(compose.applyPresetFiles.called, 'No: nothing happens');
+			assert.isFalse(compose.applyPresetFilemode.called);
+
+			showDialog.firstCall.args[0](Et2Dialog.YES_BUTTON);
+			assert.isTrue(compose.applyPresetFilemode.calledOnceWith('link'), 'the mode counts as chosen by the user');
+			assert.isTrue(compose.applyPresetFiles.calledOnce);
+			assert.isTrue(compose.applyPresetFilemode.calledBefore(compose.applyPresetFiles));
+		}
+		finally
+		{
+			showDialog.restore();
+		}
+	});
+
+	it('does not ask when the requested filemode is the current one', () =>
+	{
+		const showDialog = sinon.stub(Et2Dialog, 'show_dialog');
+		try
+		{
+			app.setCompose(composeWindow, {data: {files: {file: ['vfs://default/home/asig/a.pdf'], filemode: 'attach'}}});
+
+			assert.isFalse(showDialog.called);
+			assert.isFalse(compose.applyPresetFilemode.called);
+			assert.isTrue(compose.applyPresetFiles.calledOnce);
+		}
+		finally
+		{
+			showDialog.restore();
+		}
+	});
+
+	it('falls back to the basename and a generic mime when a caller sends only paths', () =>
+	{
+		app.setCompose(composeWindow, {data: {files: {file: ['vfs://default/apps/addressbook/12/.entry', 'vfs://default/home/asig/a.pdf']}}});
+
+		assert.deepEqual(compose.applyPresetFiles.firstCall.args[0], [
+			{path: 'vfs://default/apps/addressbook/12/.entry', name: '.entry', type: 'application/octet-stream'},
+			{path: 'vfs://default/home/asig/a.pdf', name: 'a.pdf', type: 'application/octet-stream'},
+		]);
+	});
+
+	it('keeps the classic appendix_data + submit() postback for a non-JMAP popup', () =>
+	{
+		compose.isJmapModeActive = false;
+
+		app.setCompose(composeWindow, {data: {files: {file: ['vfs://default/home/asig/a.pdf'], filemode: 'attach'}}});
+
+		assert.isFalse(compose.applyPresetFiles.called);
+		assert.isTrue(appendix.set_value.calledOnce);
+		assert.isTrue(submit.calledOnce);
+	});
+
+	it('still handles forward-as-attachment ids first', () =>
+	{
+		app.setCompose(composeWindow, {data: {emails: {ids: 'mail::1::2::3::4,mail::1::2::3::5'}}});
+
+		assert.isTrue(compose.mergeForwardAttachments.calledOnceWith(['mail::1::2::3::4', 'mail::1::2::3::5']));
+		assert.isFalse(compose.applyPresetFiles.called);
+		assert.isFalse(submit.called);
+	});
+
+	it('vfsFilesFromComposeContent() tolerates a missing or malformed files entry', () =>
+	{
+		assert.deepEqual(app.vfsFilesFromComposeContent(undefined), []);
+		assert.deepEqual(app.vfsFilesFromComposeContent({}), []);
+		assert.deepEqual(app.vfsFilesFromComposeContent({file: 'not-an-array'}), []);
+		assert.deepEqual(app.vfsFilesFromComposeContent({file: ['', 'vfs://default/x/y.txt']}),
+			[{path: 'vfs://default/x/y.txt', name: 'y.txt', type: 'application/octet-stream'}]);
+	});
+});

--- a/mail/js/test/MailComposeApplyPresetFilemode.test.ts
+++ b/mail/js/test/MailComposeApplyPresetFilemode.test.ts
@@ -1,0 +1,142 @@
+import {assert} from "@open-wc/testing";
+import * as sinon from "sinon";
+import "./MailAppImportStub";
+// breaks the et2_core_widget <-> Et2Widget import cycle (ClassWithAttributes TDZ) the same
+// way the other mail tests do, before compose.ts pulls it in transitively
+import "../../../api/js/etemplate/Et2Widget/Et2Widget";
+import {MailCompose} from "../compose";
+
+/**
+ * MailCompose.applyPresetFilemode(): a "send files as" mode chosen in ANOTHER app (filemanager's
+ * Download link / Readonly share / Writable share actions, preset.filemode for a fresh popup or
+ * MailApp.setCompose()'s confirmed yes/no question for an open one) has to count as the user's
+ * explicit choice, or currentEmailFields() keeps sending the files as plain attachments: it only
+ * ever converts to share links when `explicitShareModeChosen` is set, and a programmatic
+ * set_value() on the widget never sets it (found live 2026-09-10 - widget said "link", the flag
+ * stayed false).
+ *
+ * Setup: a bare MailCompose over a fake app and a hand-built et2 with the four widgets
+ * checkSharingFilemode() touches. egw.app('stylite') is switchable: the expiration/password
+ * fields only ever unlock with EPL, and without it share_rw is downgraded to share_ro, exactly
+ * as checkSharingFilemode() does for a genuine pick.
+ */
+describe('MailCompose.applyPresetFilemode()', () =>
+{
+	let compose : MailCompose;
+	let filemode : any;
+	let expiration : any;
+	let password : any;
+	let messages : string[];
+	let hasStylite : boolean;
+
+	beforeEach(() =>
+	{
+		messages = [];
+		hasStylite = false;
+		let value = 'attach';
+		filemode = {
+			get_value: () => value,
+			set_value: sinon.spy((v : string) => { value = v; }),
+			select_options: [{value: 'attach', label: 'Attachment'}, {value: 'link', label: 'Download link'}],
+		};
+		expiration = {set_readonly: sinon.spy()};
+		password = {set_readonly: sinon.spy(), set_suggest: sinon.spy()};
+		const widgets : any = {filemode, expiration, password};
+		const et2 = {
+			getWidgetById: (id : string) => widgets[id],
+			getArrayMgr: () => ({getEntry: () => undefined}),
+		};
+		const egw = {
+			app: (name : string) => name === 'stylite' && hasStylite,
+			lang: (s : string) => s,
+			message: (m : string) => { messages.push(m); },
+		};
+		compose = new MailCompose({egw} as any);
+		(compose as any).et2 = et2;
+	});
+
+	it('sets the widget, unlocks expiration/password (EPL) and marks the share mode as explicitly chosen', () =>
+	{
+		hasStylite = true;
+		compose.applyPresetFilemode('link');
+
+		assert.isTrue(filemode.set_value.calledOnceWith('link'));
+		assert.equal(filemode.get_value(), 'link');
+		assert.isTrue(expiration.set_readonly.calledWith(false));
+		assert.isTrue(password.set_readonly.calledWith(false));
+		assert.isTrue((compose as any).explicitShareModeChosen, 'what the send path gates on');
+	});
+
+	it('a plain "attach" keeps the fields locked and the flag off', () =>
+	{
+		hasStylite = true;
+		compose.applyPresetFilemode('attach');
+
+		assert.isFalse(filemode.set_value.called, 'already attach, nothing to set');
+		assert.isTrue(expiration.set_readonly.calledWith(true));
+		assert.isFalse((compose as any).explicitShareModeChosen);
+	});
+
+	it('going back to "attach" after a share mode clears the flag again', () =>
+	{
+		compose.applyPresetFilemode('link');
+		compose.applyPresetFilemode('attach');
+
+		assert.equal(filemode.get_value(), 'attach');
+		assert.isFalse((compose as any).explicitShareModeChosen);
+	});
+
+	it('without EPL the fields stay locked even for a share mode', () =>
+	{
+		compose.applyPresetFilemode('link');
+
+		assert.equal(filemode.get_value(), 'link');
+		assert.isTrue(expiration.set_readonly.calledWith(true));
+		assert.isTrue((compose as any).explicitShareModeChosen);
+	});
+
+	it('share_rw without EPL is downgraded to share_ro, and still counts as chosen', () =>
+	{
+		compose.applyPresetFilemode('share_rw');
+
+		assert.equal(filemode.get_value(), 'share_ro');
+		assert.isTrue((compose as any).explicitShareModeChosen);
+		assert.lengthOf(messages, 1, 'the "requires EPL" notice');
+	});
+
+	it('ignores an empty mode and a missing widget', () =>
+	{
+		compose.applyPresetFilemode('');
+		assert.isFalse(filemode.set_value.called);
+
+		(compose as any).et2 = {getWidgetById: () => undefined, getArrayMgr: () => ({getEntry: () => undefined})};
+		compose.applyPresetFilemode('link');
+		assert.isFalse((compose as any).explicitShareModeChosen);
+	});
+
+	describe('applyPresetFiles() path normalisation', () =>
+	{
+		it('strips the vfs://default url prefix the classic preset params carry, keeps a bare path', () =>
+		{
+			const merged : any[] = [];
+			(compose as any).mergeAttachmentEntries = (entries : any[]) => { merged.push(...entries); };
+
+			compose.applyPresetFiles([
+				{path: 'vfs://default/apps/acemailstor/494433/original_data/raw/raw_mail.eml', name: 'raw_mail.eml', type: 'message/rfc822'},
+				{path: '/home/asig/a.pdf', name: 'a.pdf', type: 'application/pdf'},
+			]);
+
+			assert.deepEqual(merged.map((e) => e.jmapVfsPath),
+				['/apps/acemailstor/494433/original_data/raw/raw_mail.eml', '/home/asig/a.pdf']);
+			assert.deepEqual(merged.map((e) => e.name), ['raw_mail.eml', 'a.pdf']);
+		});
+
+		it('vfsPathFromPreset() only strips the exact prefix in front of a slash', () =>
+		{
+			assert.equal(MailCompose.vfsPathFromPreset('vfs://default/x/y'), '/x/y');
+			assert.equal(MailCompose.vfsPathFromPreset('/x/y'), '/x/y');
+			assert.equal(MailCompose.vfsPathFromPreset('vfs://defaultx/y'), 'vfs://defaultx/y');
+			assert.equal(MailCompose.vfsPathFromPreset(''), '');
+		});
+	});
+});


### PR DESCRIPTION
Filemanager -> Share -> Mail -> Attach (also addressbook's vCard-attach and re-attaching a mail attachment via ajax_vfsOpen) with a compose popup already open goes through egw.openWithinWindow()'s "Select an opened dialog" chooser, which calls MailApp.setCompose(popup, content) inside that popup. setCompose() only merged the forward-as-attachment shape ({data:{emails:{ids}}}) client-side; the VFS-files shape ({data:{files:{file:[...]}}}) fell through to the classic appendix_data + submit() postback, which the client-side compose (mail/compose.php) has nothing to answer: the popup showed its loading prompt for ever and no request even left. Reproduced on dev5 2026-09-10.

In JMAP mode the files now go through MailCompose.applyPresetFiles(), the same bare jmapVfsPath marker rows composeWithPreset({files}) builds for a fresh popup, resolved at send time as before. A non-JMAP popup keeps the classic postback. The three callers pass parallel name[]/type[] arrays along in the content so the attachment carries the real filename and mime type (what the JMAP upload declares) instead of the path's basename and application/octet-stream.

A requested filemode that differs from the popup's (Download link / Readonly share / Writable share) still asks the same yes/no question first. Found reviewing this live: setting the widget after Yes is not enough - currentEmailFields() only converts attachments into share links when explicitShareModeChosen is set, which a programmatic set_value() never does (checkSharingFilemode() sees no node), so the send would have attached the files anyway. New MailCompose.applyPresetFilemode() applies a caller-chosen mode as the explicit choice it is (the user picked it in filemanager and confirmed it here), runs checkSharingFilemode()'s load-time variant for the expiration/password fields, and is used by composeWithPreset({filemode}) too, whose contentCopy.filemode had the same gap for a fresh popup.

Tests: mail/js/test/MailAppSetComposeVfsFiles.test.ts (JMAP branch never submits, classic popup still does, forward ids still come first, the yes/no question and its No, name/type fallbacks) and mail/js/test/MailComposeApplyPresetFilemode.test.ts (flag, EPL-gated field unlock, share_rw downgrade, attach clears the flag). Verified live: the odt shows up as an attachment row with its opendocument mime type, no spinner; after Yes for "Download link" the widget reads link, the flag is set, no second dialog.